### PR TITLE
Update app.js and readme.md typos

### DIFF
--- a/examples/flask-webapp/README.md
+++ b/examples/flask-webapp/README.md
@@ -15,4 +15,7 @@ AUTH0_CLIENT_ID=myCoolClientId
 AUTH0_DOMAIN=samples.auth0.com
 AUTH0_CALLBACK_URL=http://localhost:3000/auth/auth0/callback
 ````
+
+If you're using Windows, you should add a newline to the .env file if you receive an issue regarding the callback URL being truncated, for example, you see callbac instead of callback. 
+
 Once you've set those 4 enviroment variables, just run `python server.py` and try calling [http://localhost:3000/](http://localhost:3000/)

--- a/examples/flask-webapp/public/app.js
+++ b/examples/flask-webapp/public/app.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
     var widget = new Auth0Widget({
-        // All this properties are set on auth0-variables.js
+        // All this properties are set on the .env file
         domain: AUTH0_DOMAIN,
         clientID: AUTH0_CLIENT_ID,
         callbackURL: AUTH0_CALLBACK_URL,


### PR DESCRIPTION
Updated an outdated comment in the app.js file and added a note on the readme file regarding a newline needed if the user receives a truncated callback URL error. Zendesk link related to this error: https://auth0.zendesk.com/agent/tickets/2705 https://github.com/auth0/auth0-python/issues/6