### PR TITLE
Do not hardcode scope for just openid

### DIFF
--- a/auth0/v2/authentication/database.py
+++ b/auth0/v2/authentication/database.py
@@ -13,7 +13,7 @@ class Database(AuthenticationBase):
         self.domain = domain
 
     def login(self, client_id, username, password, connection, id_token=None,
-              grant_type='password', device=None):
+              grant_type='password', device=None, scope='openid'):
         """Login using username and password
 
         Given the user credentials and the connection specified, it will do
@@ -33,7 +33,7 @@ class Database(AuthenticationBase):
                 'connection': connection,
                 'device': device,
                 'grant_type': grant_type,
-                'scope': 'openid',
+                'scope': scope,
             },
             headers={'Content-Type': 'application/json'}
         )

--- a/auth0/v2/authentication/delegated.py
+++ b/auth0/v2/authentication/delegated.py
@@ -13,7 +13,7 @@ class Delegated(AuthenticationBase):
         self.domain = domain
 
     def get_token(self, client_id, target, api_type, grant_type,
-                  id_token=None, refresh_token=None):
+                  id_token=None, refresh_token=None, scope='openid'):
 
         """Obtain a delegation token.
         """
@@ -26,7 +26,7 @@ class Delegated(AuthenticationBase):
             'client_id': client_id,
             'grant_type': grant_type,
             'target': target,
-            'scope': 'openid',
+            'scope': scope,
             'api_type': api_type,
         }
 

--- a/auth0/v2/authentication/passwordless.py
+++ b/auth0/v2/authentication/passwordless.py
@@ -62,7 +62,7 @@ class Passwordless(AuthenticationBase):
             headers={'Content-Type': 'application/json'}
         )
 
-    def sms_login(self, client_id, phone_number, code):
+    def sms_login(self, client_id, phone_number, code, scope='openid'):
         """Login using phone number/verification code.
         """
 
@@ -74,7 +74,7 @@ class Passwordless(AuthenticationBase):
                 'grant_type': 'password',
                 'username': phone_number,
                 'password': code,
-                'scope': 'openid',
+                'scope': scope,
             },
             headers={'Content-Type': 'application/json'}
         )

--- a/auth0/v2/authentication/social.py
+++ b/auth0/v2/authentication/social.py
@@ -12,7 +12,7 @@ class Social(AuthenticationBase):
     def __init__(self, domain):
         self.domain = domain
 
-    def login(self, client_id, access_token, connection):
+    def login(self, client_id, access_token, connection, scope='openid'):
         """Login using a social provider's access token
 
         Given the social provider's access_token and the connection specified,
@@ -37,7 +37,7 @@ class Social(AuthenticationBase):
                 'client_id': client_id,
                 'access_token': access_token,
                 'connection': connection,
-                'scope': 'openid',
+                'scope': scope,
             },
             headers={'Content-Type': 'application/json'}
         )

--- a/auth0/v2/test/authentication/test_database.py
+++ b/auth0/v2/test/authentication/test_database.py
@@ -16,7 +16,8 @@ class TestDatabase(unittest.TestCase):
                 id_token='idt',
                 connection='conn',
                 device='dev',
-                grant_type='gt')
+                grant_type='gt',
+                scope='openid profile')
 
         args, kwargs = mock_post.call_args
 
@@ -29,7 +30,7 @@ class TestDatabase(unittest.TestCase):
             'connection': 'conn',
             'device': 'dev',
             'grant_type': 'gt',
-            'scope': 'openid',
+            'scope': 'openid profile',
         })
         self.assertEqual(kwargs['headers'], {
             'Content-Type': 'application/json'

--- a/auth0/v2/test/authentication/test_delegated.py
+++ b/auth0/v2/test/authentication/test_delegated.py
@@ -14,7 +14,8 @@ class TestDelegated(unittest.TestCase):
                     target='tgt',
                     api_type='apt',
                     grant_type='gt',
-                    id_token='idt')
+                    id_token='idt',
+                    scope='openid profile')
 
         args, kwargs = mock_post.call_args
 
@@ -24,7 +25,7 @@ class TestDelegated(unittest.TestCase):
             'grant_type': 'gt',
             'id_token': 'idt',
             'target': 'tgt',
-            'scope': 'openid',
+            'scope': 'openid profile',
             'api_type': 'apt',
         })
         self.assertEqual(kwargs['headers'], {

--- a/auth0/v2/test/authentication/test_passwordless.py
+++ b/auth0/v2/test/authentication/test_passwordless.py
@@ -68,3 +68,27 @@ class TestPasswordless(unittest.TestCase):
         self.assertEqual(kwargs['headers'], {
             'Content-Type': 'application/json'
         })
+
+    @mock.patch('auth0.v2.authentication.passwordless.Passwordless.post')
+    def test_sms_login_with_scope(self, mock_post):
+
+        p = Passwordless('my.domain.com')
+
+        p.sms_login(client_id='cid', phone_number='123456',
+                    code='abcd', scope='openid profile')
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], 'https://my.domain.com/oauth/ro')
+        self.assertEqual(kwargs['data'], {
+            'client_id': 'cid',
+            'connection': 'sms',
+            'grant_type': 'password',
+            'username': '123456',
+            'password': 'abcd',
+            'scope': 'openid profile',
+        })
+        self.assertEqual(kwargs['headers'], {
+            'Content-Type': 'application/json'
+        })
+

--- a/auth0/v2/test/authentication/test_social.py
+++ b/auth0/v2/test/authentication/test_social.py
@@ -22,3 +22,22 @@ class TestSocial(unittest.TestCase):
         self.assertEqual(kwargs['headers'], {
             'Content-Type': 'application/json'
         })
+
+    @mock.patch('auth0.v2.authentication.social.Social.post')
+    def test_login_with_scope(self, mock_post):
+        s = Social('a.b.c')
+        s.login(client_id='cid', access_token='atk',
+                connection='conn', scope='openid profile')
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual('https://a.b.c/oauth/access_token', args[0])
+        self.assertEqual(kwargs['data'], {
+            'client_id': 'cid',
+            'access_token': 'atk',
+            'connection': 'conn',
+            'scope': 'openid profile',
+        })
+        self.assertEqual(kwargs['headers'], {
+            'Content-Type': 'application/json'
+        })


### PR DESCRIPTION
Each of the authentication types currently hardcodes scope to use
'openid' only. As this is something that a user might want to change,
make this a parameter for each of the login/get_token methods.

Also, adjust tests accordingly.