### PR TITLE
Updated Rules.all to exclude enabled parameter if enabled=None

### DIFF
--- a/auth0/v3/management/rules.py
+++ b/auth0/v3/management/rules.py
@@ -46,8 +46,10 @@ class Rules(object):
 
         params = {'fields': ','.join(fields) or None,
                   'include_fields': str(include_fields).lower(),
-                  'enabled': str(enabled).lower(),
                   'stage': stage}
+
+        if enabled != None:
+            params['enabled'] = str(enabled).lower()
 
         return self.client.get(self._url(), params=params)
 

--- a/auth0/v3/test/management/test_rules.py
+++ b/auth0/v3/test/management/test_rules.py
@@ -31,6 +31,16 @@ class TestRules(unittest.TestCase):
                                             'enabled': 'false',
                                             'stage': 'stage'})
 
+        c.all(stage='stage', enabled=None, fields=['a', 'b'],
+              include_fields=False)
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/rules', args[0])
+        self.assertEqual(kwargs['params'], {'fields': 'a,b',
+                                            'include_fields': 'false',
+                                            'stage': 'stage'})
+
     @mock.patch('auth0.v3.management.rules.RestClient')
     def test_create(self, mock_rc):
         mock_instance = mock_rc.return_value


### PR DESCRIPTION
I found a bug in the Rules.all method that causes limited behavior in the Python API compared to what is allowed by the REST API.  The REST API specified the boolean parameter `enabled`, which if `true` will result in only rules that are enabled being returned by the API.  If `false`, only rules that are disabled will be returned by the API.  If this parameter is not provided, then all rules will be returned regardless of whether they are enabled or disabled.

The Python API only supports providing `True` or `False` for the `enabled` parameter in the Rules.all function, which results in the enabled parameter always being included in the request to the REST API.  This means that one cannot request all rules regardless of enabled or disabled in a single request.

I've updated the Rules.all function to accept `None` as a value for the `enabled` parameter.  If `None` is provided, the `enabled` parameter will not be included in the request at all and the response will contain all rules regardless of whether they are enabled or deleted.  If a value other than `None` is provided, then the function behaves as it did before this change.