### PR TITLE
Added refresh_token to GetToken

### DIFF
--- a/auth0/v3/authentication/get_token.py
+++ b/auth0/v3/authentication/get_token.py
@@ -170,3 +170,33 @@ class GetToken(AuthenticationBase):
             },
             headers={'Content-Type': 'application/json'}
         )
+
+    def refresh_token(self, client_id, client_secret, refresh_token, grant_type='refresh_token'):
+        """Calls oauth/token endpoint with refresh token grant type
+
+        Use this endpoint to refresh an access token, using the refresh token you got during authorization.
+
+        Args:
+            grant_type (str): Denotes the flow you're using. For refresh token
+            use refresh_token
+
+            client_id (str): your application's client Id
+
+            client_secret (str): you application's client Secret
+
+            refresh_token (str): The refresh token returned from the initial token request.
+
+        Returns:
+            access_token, id_token
+        """
+
+        return self.post(
+            'https://%s/oauth/token' % self.domain,
+            data={
+                'client_id': client_id,
+                'client_secret': client_secret,
+                'refresh_token': refresh_token,
+                'grant_type': grant_type
+            },
+            headers={'Content-Type': 'application/json'}
+        )

--- a/auth0/v3/test/authentication/test_get_token.py
+++ b/auth0/v3/test/authentication/test_get_token.py
@@ -108,3 +108,25 @@ class TestGetToken(unittest.TestCase):
         self.assertEqual(kwargs['headers'], {
             'Content-Type': 'application/json'
         })
+
+    @mock.patch('auth0.v3.authentication.get_token.GetToken.post')
+    def test_refresh_token(self, mock_post):
+        g = GetToken('my.domain.com')
+
+        g.refresh_token(client_id='cid',
+                        client_secret='clsec',
+                        refresh_token='rt',
+                        grant_type='gt')
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], 'https://my.domain.com/oauth/token')
+        self.assertEqual(kwargs['data'], {
+            'client_id': 'cid',
+            'client_secret': 'clsec',
+            'refresh_token': 'rt',
+            'grant_type': 'gt'
+        })
+        self.assertEqual(kwargs['headers'], {
+            'Content-Type': 'application/json'
+        })


### PR DESCRIPTION
The Auth0 Authentication API supports the `refresh_token` grant type, but the auth0-python package does not support it in the Python SDK.  I've added a new method to GetToken.py called `refresh_token`, which accepts `client_id`, `client_secret`, `refresh_token`, and `grant_type='refresh_token'` as arguments.  This calls the `/oauth/token` endpoint of the Auth0 Authentication API with the `refresh_token` grant type and returns an `access_token` and `id_token`.  I also added test for this new method.