### PR TITLE
Added upsert parameter to import users job

### DIFF
--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -41,7 +41,7 @@ class Jobs(object):
         url = self._url('%s/errors' % (id))
         return self.client.get(url)
 
-    def import_users(self, connection_id, file_obj):
+    def import_users(self, connection_id, file_obj, upsert=False):
         """Imports users to a connection from a file.
 
         Args:
@@ -51,8 +51,13 @@ class Jobs(object):
             file_obj (file): A file-like object to upload. The format for
                 this file is explained in: https://auth0.com/docs/bulk-import
         """
+
+        # This conversion is necessary because the requests library will convert True to 'True'.
+        # The Management API only respects 'true'
+        upsert = 'true' if upsert else 'false'
+
         return self.client.file_post(self._url('users-imports'),
-                                     data={'connection_id': connection_id},
+                                     data={'connection_id': connection_id, 'upsert': upsert},
                                      files={'users': file_obj})
 
     def send_verification_email(self, body):

--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -54,7 +54,7 @@ class Jobs(object):
 
         # This conversion is necessary because the requests library will convert True to 'True'.
         # The Management API only respects 'true'
-        upsert = 'true' if upsert else 'false'
+        upsert = str(upsert).lower()
 
         return self.client.file_post(self._url('users-imports'),
                                      data={'connection_id': connection_id, 'upsert': upsert},

--- a/auth0/v3/test/management/test_jobs.py
+++ b/auth0/v3/test/management/test_jobs.py
@@ -36,7 +36,21 @@ class TestJobs(unittest.TestCase):
 
         mock_instance.file_post.assert_called_with(
             'https://domain/api/v2/jobs/users-imports',
-            data={'connection_id': '1234'},
+            data={'connection_id': '1234', 'upsert': 'false'},
+            files={'users': {}}
+        )
+
+        j.import_users(connection_id='1234', file_obj={}, upsert=True)
+        mock_instance.file_post.assert_called_with(
+            'https://domain/api/v2/jobs/users-imports',
+            data={'connection_id': '1234', 'upsert': 'true'},
+            files={'users': {}}
+        )
+
+        j.import_users(connection_id='1234', file_obj={}, upsert=False)
+        mock_instance.file_post.assert_called_with(
+            'https://domain/api/v2/jobs/users-imports',
+            data={'connection_id': '1234', 'upsert': 'false'},
             files={'users': {}}
         )
 


### PR DESCRIPTION
The Auth0 Management API supports an `upsert` boolean parameter on the `jobs/users-imports` endpoint, but this parameter is not currently supported in the auth0-python package.  I've added support for this parameter, making it `False` by default so existing users should not be impacted.  I also updated unit tests for jobs to honor this change.

@Annyv2 could you please review this PR and let me know if I need to change anything?