### PR TITLE
fixed base.py to honor response status code in Auth0Error

### DIFF
--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -20,7 +20,7 @@ class AuthenticationBase(object):
             return response.text
         else:
             if 'error' in text:
-                raise Auth0Error(status_code=text['error'],
+                raise Auth0Error(status_code=response.status_code,
                                  error_code=text['error'],
                                  message=text['error_description'])
         return text

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -25,10 +25,11 @@ class TestBase(unittest.TestCase):
 
         mock_post.return_value.text = '{"error": "e0",' \
                                       '"error_description": "desc"}'
+        mock_post.return_value.status_code = 500
 
         with self.assertRaises(Auth0Error) as context:
             data = ab.post('the-url', data={'a': 'b'}, headers={'c': 'd'})
 
-        self.assertEqual(context.exception.status_code, 'e0')
+        self.assertEqual(context.exception.status_code, 500)
         self.assertEqual(context.exception.error_code, 'e0')
         self.assertEqual(context.exception.message, 'desc')


### PR DESCRIPTION
I discovered that Auth0Error objects do not always report the correct status code in the `status_code` property.  In the `_process_response` method of base.py, the `Auth0Error.status_code` is set to the `error` property of the response text instead of the response status_code.  In most cases this is fine because the Auth0 API returns a valid status code in the `error` property, but I found that the API does not always do this.

For example, when calling `oauth/token` with a user who is blocked due to 'too many attempts' the response status code is `429` and the `error = 'Too many attempts'`.  This may be a bug in the API itself, but it is safer for the auth0-python SDK to use the true status code in these Auth0Error objects so that consuming systems can always expect a valid status code.