### PR TITLE
Unescaped `user_id` in URL lead to suprises

### DIFF
--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -1,3 +1,5 @@
+import urllib
+
 from .rest import RestClient
 
 
@@ -21,7 +23,7 @@ class Users(object):
     def _url(self, id=None):
         url = 'https://%s/api/v2/users' % self.domain
         if id is not None:
-            return url + '/' + id
+            return url + '/' + urllib.quote(id)
         return url
 
     def list(self, page=0, per_page=25, sort=None, connection=None, q=None,


### PR DESCRIPTION
`user_id`s can contain characters which are not URL-save like `@`. This patch adds proper escaping so `auth0api.users.get('auth0|user@example.com')` returns an existing user instead of 404.

See also https://community.auth0.com/questions/12952/types-of-user-id-allowed