### PR TITLE
fixes handling of error responses

### DIFF
--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -105,8 +105,8 @@ class RestClient(object):
     def _process_response(self, response):
         text = json.loads(response.text) if response.text else {}
 
-        if isinstance(text, dict) and 'errorCode' in text:
+        if isinstance(text, dict) and 'error' in text:
             raise Auth0Error(status_code=text['statusCode'],
-                             error_code=text['errorCode'],
+                             error_code=text['error'],
                              message=text['message'])
         return text

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -35,7 +35,7 @@ class TestRest(unittest.TestCase):
         headers = {'Authorization': 'Bearer a-token'}
 
         mock_get.return_value.text = '{"statusCode": 999,' \
-                                     ' "errorCode": "code",' \
+                                     ' "error": "code",' \
                                      ' "message": "message"}'
 
         with self.assertRaises(Auth0Error) as context:
@@ -66,7 +66,7 @@ class TestRest(unittest.TestCase):
         rc = RestClient(jwt='a-token', telemetry=False)
 
         mock_post.return_value.text = '{"statusCode": 999,' \
-                                      ' "errorCode": "code",' \
+                                      ' "error": "code",' \
                                       ' "message": "message"}'
 
         with self.assertRaises(Auth0Error) as context:
@@ -97,7 +97,7 @@ class TestRest(unittest.TestCase):
         rc = RestClient(jwt='a-token', telemetry=False)
 
         mock_patch.return_value.text = '{"statusCode": 999,' \
-                                       ' "errorCode": "code",' \
+                                       ' "error": "code",' \
                                        ' "message": "message"}'
 
         with self.assertRaises(Auth0Error) as context:
@@ -124,7 +124,7 @@ class TestRest(unittest.TestCase):
         rc = RestClient(jwt='a-token', telemetry=False)
 
         mock_delete.return_value.text = '{"statusCode": 999,' \
-                                        ' "errorCode": "code",' \
+                                        ' "error": "code",' \
                                         ' "message": "message"}'
 
         with self.assertRaises(Auth0Error) as context:


### PR DESCRIPTION
API now appears to return key `error` instead of `errorCode`, e.g.:

`{'statusCode': 401, 'error': 'Unauthorized', 'message': 'Invalid token'}`

maintained exception attribute `error_code` for backwards compatibility.

Reported in auth0/auth0-python#86