### PR TITLE
Raise Auth0Error for bad status code

### DIFF
--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -1,6 +1,7 @@
 import json
 import requests
 from ..exceptions import Auth0Error
+from abc import ABCMeta, abstractmethod
 
 
 UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
@@ -29,6 +30,9 @@ class AuthenticationBase(object):
 
 
 class Response(object):
+    __metaclass__ = ABCMeta
+
+
     def __init__(self, status_code, content):
         self._status_code = status_code
         self._content = content
@@ -45,9 +49,11 @@ class Response(object):
         return self._status_code is None or self._status_code >= 400
 
     # Adding these methods to force implementation in subclasses because they are references in this parent class
+    @abstractmethod
     def _error_code(self):
         raise NotImplementedError
 
+    @abstractmethod
     def _error_message(self):
         raise NotImplementedError
 

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -55,7 +55,7 @@ class Response(object):
 class JsonResponse(Response):
     def __init__(self, response):
         content = json.loads(response.text)
-        super(Response, self).__init__(response.status_code, content)
+        super(JsonResponse, self).__init__(response.status_code, content)
 
     def _error_code(self):
         if 'error' in self._content:
@@ -71,7 +71,7 @@ class JsonResponse(Response):
 
 class PlainResponse(Response):
     def __init__(self, response):
-        super(Response, self).__init__(response.status_code, response.text)
+        super(PlainResponse, self).__init__(response.status_code, response.text)
 
     def _error_code(self):
         return UNKNOWN_ERROR
@@ -82,7 +82,7 @@ class PlainResponse(Response):
 
 class EmptyResponse(Response):
     def __init__(self, status_code):
-        super(Response, self).__init__(status_code, '')
+        super(EmptyResponse, self).__init__(status_code, '')
 
     def _error_code(self):
         return UNKNOWN_ERROR

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -2,7 +2,9 @@ import json
 import requests
 from ..exceptions import Auth0Error
 
+
 UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
+
 
 class AuthenticationBase(object):
 
@@ -25,6 +27,7 @@ class AuthenticationBase(object):
         except ValueError:
             return PlainResponse(response)
 
+
 class Response(object):
     def __init__(self, status_code, content):
         self._status_code = status_code
@@ -41,10 +44,18 @@ class Response(object):
     def _is_error(self):
         return self._status_code is None or self._status_code >= 400
 
+    # Adding these methods to force implementation in subclasses because they are references in this parent class
+    def _error_code(self):
+        raise NotImplementedError
+
+    def _error_message(self):
+        raise NotImplementedError
+
+
 class JsonResponse(Response):
     def __init__(self, response):
         content = json.loads(response.text)
-        super().__init__(response.status_code, content)
+        super(Response, self).__init__(response.status_code, content)
 
     def _error_code(self):
         if 'error' in self._content:
@@ -57,9 +68,10 @@ class JsonResponse(Response):
     def _error_message(self):
         return self._content.get('error_description', '')
 
+
 class PlainResponse(Response):
     def __init__(self, response):
-        super().__init__(response.status_code, response.text)
+        super(Response, self).__init__(response.status_code, response.text)
 
     def _error_code(self):
         return UNKNOWN_ERROR
@@ -67,9 +79,10 @@ class PlainResponse(Response):
     def _error_message(self):
         return self._content
 
+
 class EmptyResponse(Response):
     def __init__(self, status_code):
-        super().__init__(status_code, '')
+        super(Response, self).__init__(status_code, '')
 
     def _error_code(self):
         return UNKNOWN_ERROR

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -2,6 +2,7 @@ import json
 import requests
 from ..exceptions import Auth0Error
 
+UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
 
 class AuthenticationBase(object):
 
@@ -14,13 +15,64 @@ class AuthenticationBase(object):
         return requests.get(url=url, params=params, headers=headers).text
 
     def _process_response(self, response):
+        return self._parse(response).content()
+
+    def _parse(self, response):
+        if not response.text:
+            return EmptyResponse(response.status_code)
         try:
-            text = json.loads(response.text) if response.text else {}
+            return JsonResponse(response)
         except ValueError:
-            return response.text
+            return PlainResponse(response)
+
+class Response(object):
+    def __init__(self, status_code, content):
+        self._status_code = status_code
+        self._content = content
+
+    def content(self):
+        if self._is_error():
+            raise Auth0Error(status_code=self._status_code,
+                             error_code=self._error_code(),
+                             message=self._error_message())
         else:
-            if response.status_code is None or response.status_code >= 400:
-                raise Auth0Error(status_code=response.status_code,
-                                 error_code=text.get('error', ''),
-                                 message=text.get('error_description', ''))
-        return text
+            return self._content
+
+    def _is_error(self):
+        return self._status_code is None or self._status_code >= 400
+
+class JsonResponse(Response):
+    def __init__(self, response):
+        content = json.loads(response.text)
+        super().__init__(response.status_code, content)
+
+    def _error_code(self):
+        if 'error' in self._content:
+            return self._content.get('error')
+        elif 'code' in self._content:
+            return self._content.get('code')
+        else:
+            return UNKNOWN_ERROR
+
+    def _error_message(self):
+        return self._content.get('error_description', '')
+
+class PlainResponse(Response):
+    def __init__(self, response):
+        super().__init__(response.status_code, response.text)
+
+    def _error_code(self):
+        return UNKNOWN_ERROR
+
+    def _error_message(self):
+        return self._content
+
+class EmptyResponse(Response):
+    def __init__(self, status_code):
+        super().__init__(status_code, '')
+
+    def _error_code(self):
+        return UNKNOWN_ERROR
+
+    def _error_message(self):
+        return ''

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -1,7 +1,6 @@
 import json
 import requests
 from ..exceptions import Auth0Error
-from abc import ABCMeta, abstractmethod
 
 
 UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
@@ -30,9 +29,6 @@ class AuthenticationBase(object):
 
 
 class Response(object):
-    __metaclass__ = ABCMeta
-
-
     def __init__(self, status_code, content):
         self._status_code = status_code
         self._content = content
@@ -49,11 +45,9 @@ class Response(object):
         return self._status_code is None or self._status_code >= 400
 
     # Adding these methods to force implementation in subclasses because they are references in this parent class
-    @abstractmethod
     def _error_code(self):
         raise NotImplementedError
 
-    @abstractmethod
     def _error_message(self):
         raise NotImplementedError
 

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -5,6 +5,9 @@ import requests
 from ..exceptions import Auth0Error
 
 
+UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
+
+
 class RestClient(object):
 
     """Provides simple methods for handling all RESTful api endpoints. """
@@ -103,10 +106,71 @@ class RestClient(object):
         return self._process_response(response)
 
     def _process_response(self, response):
-        text = json.loads(response.text) if response.text else {}
+        return self._parse(response).content()
 
-        if isinstance(text, dict) and (response.status_code is None or response.status_code >= 400):
-            raise Auth0Error(status_code=text['statusCode'],
-                             error_code=text.get('errorCode', ''),
-                             message=text['message'])
-        return text
+    def _parse(self, response):
+        if not response.text:
+            return EmptyResponse(response.status_code)
+        try:
+            return JsonResponse(response)
+        except ValueError:
+            return PlainResponse(response)
+
+class Response(object):
+    def __init__(self, status_code, content):
+        self._status_code = status_code
+        self._content = content
+
+    def content(self):
+        if self._is_error():
+            raise Auth0Error(status_code=self._status_code,
+                             error_code=self._error_code(),
+                             message=self._error_message())
+        else:
+            return self._content
+
+    def _is_error(self):
+        return self._status_code is None or self._status_code >= 400
+
+    # Adding these methods to force implementation in subclasses because they are references in this parent class
+    def _error_code(self):
+        raise NotImplementedError
+
+    def _error_message(self):
+        raise NotImplementedError
+
+class JsonResponse(Response):
+    def __init__(self, response):
+        content = json.loads(response.text)
+        super(JsonResponse, self).__init__(response.status_code, content)
+
+    def _error_code(self):
+        if 'errorCode' in self._content:
+            return self._content.get('errorCode')
+        elif 'error' in self._content:
+            return self._content.get('error')
+        else:
+            return UNKNOWN_ERROR
+
+    def _error_message(self):
+        return self._content.get('error', self._content.get('message', ''))
+
+class PlainResponse(Response):
+    def __init__(self, response):
+        super(PlainResponse, self).__init__(response.status_code, response.text)
+
+    def _error_code(self):
+        return UNKNOWN_ERROR
+
+    def _error_message(self):
+        return self._content
+
+class EmptyResponse(Response):
+    def __init__(self, status_code):
+        super(EmptyResponse, self).__init__(status_code, '')
+
+    def _error_code(self):
+        return UNKNOWN_ERROR
+
+    def _error_message(self):
+        return ''

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -105,8 +105,8 @@ class RestClient(object):
     def _process_response(self, response):
         text = json.loads(response.text) if response.text else {}
 
-        if isinstance(text, dict) and 'errorCode' in text:
+        if isinstance(text, dict) and (response.status_code is None or response.status_code >= 400):
             raise Auth0Error(status_code=text['statusCode'],
-                             error_code=text['errorCode'],
+                             error_code=text.get('errorCode', ''),
                              message=text['message'])
         return text

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -26,6 +26,7 @@ class TestRest(unittest.TestCase):
         self.assertEqual(response, ['a', 'b'])
 
         mock_get.return_value.text = ''
+        mock_get.return_value.status_code = 200
         response = rc.get('the/url')
         self.assertEqual(response, {})
 
@@ -55,6 +56,7 @@ class TestRest(unittest.TestCase):
 
         data = {'some': 'data'}
 
+        mock_post.return_value.status_code = 200
         response = rc.post('the/url', data=data)
         mock_post.assert_called_with('the/url', data=json.dumps(data),
                                      headers=headers)

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -38,6 +38,7 @@ class TestRest(unittest.TestCase):
         mock_get.return_value.text = '{"statusCode": 999,' \
                                      ' "errorCode": "code",' \
                                      ' "message": "message"}'
+        mock_get.return_value.status_code = 999
 
         with self.assertRaises(Auth0Error) as context:
             rc.get('the/url')
@@ -70,6 +71,7 @@ class TestRest(unittest.TestCase):
         mock_post.return_value.text = '{"statusCode": 999,' \
                                       ' "errorCode": "code",' \
                                       ' "message": "message"}'
+        mock_post.return_value.status_code = 999
 
         with self.assertRaises(Auth0Error) as context:
             rc.post('the-url')
@@ -101,6 +103,7 @@ class TestRest(unittest.TestCase):
         mock_patch.return_value.text = '{"statusCode": 999,' \
                                        ' "errorCode": "code",' \
                                        ' "message": "message"}'
+        mock_patch.return_value.status_code = 999
 
         with self.assertRaises(Auth0Error) as context:
             rc.patch(url='the/url')
@@ -128,6 +131,7 @@ class TestRest(unittest.TestCase):
         mock_delete.return_value.text = '{"statusCode": 999,' \
                                         ' "errorCode": "code",' \
                                         ' "message": "message"}'
+        mock_delete.return_value.status_code = 999
 
         with self.assertRaises(Auth0Error) as context:
             rc.delete(url='the-url')

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -13,6 +13,7 @@ class TestRest(unittest.TestCase):
         headers = {'Authorization': 'Bearer a-token'}
 
         mock_get.return_value.text = '["a", "b"]'
+        mock_get.return_value.status_code = 200
 
         response = rc.get('the-url')
         mock_get.assert_called_with('the-url', params={}, headers=headers)
@@ -26,9 +27,8 @@ class TestRest(unittest.TestCase):
         self.assertEqual(response, ['a', 'b'])
 
         mock_get.return_value.text = ''
-        mock_get.return_value.status_code = 200
         response = rc.get('the/url')
-        self.assertEqual(response, {})
+        self.assertEqual(response, '')
 
     @mock.patch('requests.get')
     def test_get_errors(self, mock_get):
@@ -87,6 +87,7 @@ class TestRest(unittest.TestCase):
                    'Content-Type': 'application/json'}
 
         mock_patch.return_value.text = '["a", "b"]'
+        mock_patch.return_value.status_code = 200
 
         data = {'some': 'data'}
 
@@ -118,6 +119,7 @@ class TestRest(unittest.TestCase):
         headers = {'Authorization': 'Bearer a-token'}
 
         mock_delete.return_value.text = '["a", "b"]'
+        mock_delete.return_value.status_code = 200
 
         response = rc.delete(url='the-url/ID')
         mock_delete.assert_called_with('the-url/ID', headers=headers, params={})


### PR DESCRIPTION
I copied the logic from authentication/base.py for _process_response into management/rest.py.  This way any 400 or greater status codes will result in an Auth0Error.

The current functionality, which is based on 'error_code' being present in the response is not good enough because not all Auth0 API error response include 'error_code' and thus bad response get through when the expectation is a valid object.  For example, if I call auth0.users.create() and get a 429 response, the API response does not have an error_code and my code expects to receive a valid user profile but instead receives a `{"error": "Too Many Requests", "status_code": 429}`.

This change will make consuming the auth0-python sdk more consistent as all error responses will result in an Auth0Error instead of some resulting in an Auth0Error and other returning an error object when an Auth0 object is expected.