### PR TITLE
Add pagination to Client Grants, Resource Servers and Rules

### DIFF
--- a/auth0/v3/management/client_grants.py
+++ b/auth0/v3/management/client_grants.py
@@ -28,22 +28,21 @@ class ClientGrants(object):
         """Retrieves all client grants.
 
         Args:
-            audience (str, optional): URL Encoded audience of a Resource Server
+            audience (str, optional): URL encoded audience of a Resource Server
                 to filter
 
             page (int, optional): The result's page number (zero based).
 
             per_page (int, optional): The amount of entries per page.
-                Default: 50. Max value: 100
 
             include_totals (bool, optional): True if the query summary is
                 to be included in the result, False otherwise.
         """
 
         params = {
-            'audience': audience or None,
-            'per_page': per_page,
+            'audience': audience,
             'page': page,
+            'per_page': per_page,
             'include_totals': str(include_totals).lower()
         }
 
@@ -75,6 +74,7 @@ class ClientGrants(object):
            id (str): The id of the client grant to modify.
 
            body (dict): Attributes to modify.
+              See: https://auth0.com/docs/api/management/v2#!/Client_Grants/patch_client_grants_by_id
         """
 
         return self.client.patch(self._url(id), data=body)

--- a/auth0/v3/management/client_grants.py
+++ b/auth0/v3/management/client_grants.py
@@ -24,7 +24,7 @@ class ClientGrants(object):
             return url + '/' + id
         return url
 
-    def all(self, audience=None, page=0, per_page=50, include_totals=True):
+    def all(self, audience=None, page=None, per_page=None, include_totals=False):
         """Retrieves all client grants.
 
         Args:

--- a/auth0/v3/management/client_grants.py
+++ b/auth0/v3/management/client_grants.py
@@ -24,15 +24,28 @@ class ClientGrants(object):
             return url + '/' + id
         return url
 
-    def all(self, audience=None):
+    def all(self, audience=None, page=0, per_page=50, include_totals=True):
         """Retrieves all client grants.
 
         Args:
-           audience (str, optional): URL Encoded audience of a Resource Server
-               to filter
+            audience (str, optional): URL Encoded audience of a Resource Server
+                to filter
+
+            page (int, optional): The result's page number (zero based).
+
+            per_page (int, optional): The amount of entries per page.
+                Default: 50. Max value: 100
+
+            include_totals (bool, optional): True if the query summary is
+                to be included in the result, False otherwise.
         """
 
-        params = {'audience': audience or None}
+        params = {
+            'audience': audience or None,
+            'per_page': per_page,
+            'page': page,
+            'include_totals': str(include_totals).lower()
+        }
 
         return self.client.get(self._url(), params=params)
 

--- a/auth0/v3/management/clients.py
+++ b/auth0/v3/management/clients.py
@@ -36,7 +36,7 @@ class Clients(object):
               retrieve all fields.
 
            include_fields (bool, optional): True if the fields specified are
-              to be include in the result, False otherwise.
+              to be included in the result, False otherwise.
 
            page (int): The result's page number (zero based).
 
@@ -78,7 +78,7 @@ class Clients(object):
               retrieve all fields.
 
            include_fields (bool, optional): True if the fields specified are
-              to be include in the result, False otherwise.
+              to be included in the result, False otherwise.
         """
 
         params = {'fields': fields and ','.join(fields) or None,

--- a/auth0/v3/management/connections.py
+++ b/auth0/v3/management/connections.py
@@ -35,7 +35,7 @@ class Connections(object):
               retrieve all fields.
 
            include_fields (bool, optional): True if the fields specified are
-              to be include in the result, False otherwise.
+              to be included in the result, False otherwise.
 
            page (int): The result's page number (zero based).
 
@@ -69,7 +69,7 @@ class Connections(object):
               retrieve all fields.
 
            include_fields (bool, optional): True if the fields specified are
-              to be include in the result, False otherwise.
+              to be included in the result, False otherwise.
 
         Returns:
             A connection object.

--- a/auth0/v3/management/device_credentials.py
+++ b/auth0/v3/management/device_credentials.py
@@ -39,7 +39,7 @@ class DeviceCredentials(object):
                 retrieve all fields
 
             include_fields (bool, optional): True if the fields specified are
-                to be excluded from the result, false otherwise
+                to be included in the result, False otherwise
                 (defaults to true)
         """
 

--- a/auth0/v3/management/emails.py
+++ b/auth0/v3/management/emails.py
@@ -33,7 +33,7 @@ class Emails(object):
                 to retrieve all fields.
 
             include_fields (bool, optional): True if the fields specified are
-                to be include in the result, False otherwise.
+                to be included in the result, False otherwise.
         """
         params = {'fields': fields and ','.join(fields) or None,
                   'include_fields': str(include_fields).lower()}

--- a/auth0/v3/management/logs.py
+++ b/auth0/v3/management/logs.py
@@ -44,10 +44,10 @@ class Logs(object):
                 retrieve all fields.
 
             include_fields (bool, optional): True if the fields specified are
-                to be include in the result, False otherwise.
+                to be included in the result, False otherwise.
 
-            include_totals (bool, optional): true if a query summary must be
-                included in the result, false otherwise. Default false.
+            include_totals (bool, optional): True if the query summary is
+                to be included in the result, False otherwise.
 
             from_param (str, optional): Log Event Id to start retrieving logs. You can
                 limit the amount of logs using the take parameter

--- a/auth0/v3/management/resource_servers.py
+++ b/auth0/v3/management/resource_servers.py
@@ -41,7 +41,6 @@ class ResourceServers(object):
             page (int, optional): The result's page number (zero based).
 
             per_page (int, optional): The amount of entries per page.
-                Default: 50. Max value: 100
 
             include_totals (bool, optional): True if the query summary is
                 to be included in the result, False otherwise.
@@ -80,6 +79,7 @@ class ResourceServers(object):
            id (str): The id of the resource server to update.
 
            body (dict): Attributes to modify.
+              See: https://auth0.com/docs/api/management/v2#!/Resource_Servers/patch_resource_servers_by_id
         """
 
         return self.client.patch(self._url(id), data=body)

--- a/auth0/v3/management/resource_servers.py
+++ b/auth0/v3/management/resource_servers.py
@@ -34,7 +34,7 @@ class ResourceServers(object):
 
         return self.client.post(self._url(), data=body)
 
-    def get_all(self, page=0, per_page=50, include_totals=False):
+    def get_all(self, page=None, per_page=None, include_totals=False):
         """Retrieves all resource servers
 
         Args:

--- a/auth0/v3/management/resource_servers.py
+++ b/auth0/v3/management/resource_servers.py
@@ -34,11 +34,26 @@ class ResourceServers(object):
 
         return self.client.post(self._url(), data=body)
 
-    def get_all(self):
+    def get_all(self, page=0, per_page=50, include_totals=False):
         """Retrieves all resource servers
+
+        Args:
+            page (int, optional): The result's page number (zero based).
+
+            per_page (int, optional): The amount of entries per page.
+                Default: 50. Max value: 100
+
+            include_totals (bool, optional): True if the query summary is
+                to be included in the result, False otherwise.
         """
 
-        return self.client.get(self._url())
+        params = {
+            'page': page,
+            'per_page': per_page,
+            'include_totals': str(include_totals).lower()
+        }
+
+        return self.client.get(self._url(), params=params)
 
     def get(self, id):
         """Retrieves a resource server by its id.

--- a/auth0/v3/management/rules.py
+++ b/auth0/v3/management/rules.py
@@ -25,10 +25,13 @@ class Rules(object):
         return url
 
     def all(self, stage='login_success', enabled=True, fields=None,
-            include_fields=True):
+            include_fields=True, page=None, per_page=None, include_totals=False):
         """Retrieves a list of all rules.
 
         Args:
+            stage (str, optional):  Retrieves rules that match the execution
+                stage (defaults to login_success).
+
             enabled (bool, optional): If provided, retrieves rules that match
                 the value, otherwise all rules are retrieved.
 
@@ -40,14 +43,24 @@ class Rules(object):
                 to be included in the result, False otherwise
                 (defaults to true).
 
-            stage (str, optional):  Retrieves rules that match the execution
-                stage (defaults to login_success).
+            page (int, optional): The result's page number (zero based).
+
+            per_page (int, optional): The amount of entries per page.
+
+            include_totals (bool, optional): True if the query summary is
+                to be included in the result, False otherwise.
         """
 
-        params = {'fields': fields and ','.join(fields) or None,
-                  'include_fields': str(include_fields).lower(),
-                  'stage': stage}
+        params = {
+            'stage': stage,
+            'fields': fields and ','.join(fields) or None,
+            'include_fields': str(include_fields).lower(),
+            'page': page,
+            'per_page': per_page,
+            'include_totals': str(include_totals).lower()
+        }
 
+        # since the default is True, this is here to disable the filter
         if enabled != None:
             params['enabled'] = str(enabled).lower()
 

--- a/auth0/v3/management/rules.py
+++ b/auth0/v3/management/rules.py
@@ -71,7 +71,7 @@ class Rules(object):
 
         Args:
             body (dict): Attributes for the newly created rule,
-                please see: https://auth0.com/docs/api/v2#!/Rules/post_rules
+                See: https://auth0.com/docs/api/v2#!/Rules/post_rules
         """
         return self.client.post(self._url(), data=body)
 
@@ -107,6 +107,7 @@ class Rules(object):
         Args:
             id (str): The id of the rule to modify.
 
-            body (dict): Please see: https://auth0.com/docs/api/v2#!/Rules/patch_rules_by_id
+            body (dict): Attributes to modify.
+                See: https://auth0.com/docs/api/v2#!/Rules/patch_rules_by_id
         """
         return self.client.patch(self._url(id), data=body)

--- a/auth0/v3/management/tenants.py
+++ b/auth0/v3/management/tenants.py
@@ -30,7 +30,7 @@ class Tenants(object):
               retrieve all fields.
 
            include_fields (bool, optional): True if the fields specified are
-              to be include in the result, False otherwise.
+              to be included in the result, False otherwise.
         """
 
         params = {'fields': fields and ','.join(fields) or None,

--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -90,7 +90,7 @@ class Users(object):
                 retrieve all fields.
 
             include_fields (bool, optional): True if the fields specified are
-                to be include in the result, False otherwise.
+                to be included in the result, False otherwise.
         """
         params = {
             'fields': fields and ','.join(fields) or None,
@@ -191,8 +191,8 @@ class Users(object):
                 where order is 1 for ascending and -1 for descending.
                 For example date:-1
 
-            include_totals (bool, optional): True if a query summary are
-                to be include in the result, False otherwise.
+            include_totals (bool, optional): True if the query summary is
+                to be included in the result, False otherwise.
 
             See: https://auth0.com/docs/api/management/v2#!/Users/get_logs_by_user
         """

--- a/auth0/v3/test/management/test_client_grants.py
+++ b/auth0/v3/test/management/test_client_grants.py
@@ -19,9 +19,9 @@ class TestClientGrants(unittest.TestCase):
         self.assertEqual('https://domain/api/v2/client-grants', args[0])
         self.assertEqual(kwargs['params'], {
             'audience': None,
-            'per_page': 50,
-            'page': 0,
-            'include_totals': 'true'
+            'per_page': None,
+            'page': None,
+            'include_totals': 'false'
         })
 
         # With audience
@@ -32,13 +32,13 @@ class TestClientGrants(unittest.TestCase):
         self.assertEqual('https://domain/api/v2/client-grants', args[0])
         self.assertEqual(kwargs['params'], {
             'audience': 'http://domain.auth0.com/api/v2/',
-            'per_page': 50,
-            'page': 0,
-            'include_totals': 'true'
+            'per_page': None,
+            'page': None,
+            'include_totals': 'false'
         })
 
         # With pagination params
-        c.all(per_page=23, page=7, include_totals=False)
+        c.all(per_page=23, page=7, include_totals=True)
 
         args, kwargs = mock_instance.get.call_args
 
@@ -47,7 +47,7 @@ class TestClientGrants(unittest.TestCase):
             'audience': None,
             'per_page': 23,
             'page': 7,
-            'include_totals': 'false'
+            'include_totals': 'true'
         })
 
     @mock.patch('auth0.v3.management.client_grants.RestClient')

--- a/auth0/v3/test/management/test_client_grants.py
+++ b/auth0/v3/test/management/test_client_grants.py
@@ -19,8 +19,8 @@ class TestClientGrants(unittest.TestCase):
         self.assertEqual('https://domain/api/v2/client-grants', args[0])
         self.assertEqual(kwargs['params'], {
             'audience': None,
-            'per_page': None,
             'page': None,
+            'per_page': None,
             'include_totals': 'false'
         })
 
@@ -32,8 +32,8 @@ class TestClientGrants(unittest.TestCase):
         self.assertEqual('https://domain/api/v2/client-grants', args[0])
         self.assertEqual(kwargs['params'], {
             'audience': 'http://domain.auth0.com/api/v2/',
-            'per_page': None,
             'page': None,
+            'per_page': None,
             'include_totals': 'false'
         })
 
@@ -45,8 +45,8 @@ class TestClientGrants(unittest.TestCase):
         self.assertEqual('https://domain/api/v2/client-grants', args[0])
         self.assertEqual(kwargs['params'], {
             'audience': None,
-            'per_page': 23,
             'page': 7,
+            'per_page': 23,
             'include_totals': 'true'
         })
 

--- a/auth0/v3/test/management/test_client_grants.py
+++ b/auth0/v3/test/management/test_client_grants.py
@@ -10,19 +10,45 @@ class TestClientGrants(unittest.TestCase):
         mock_instance = mock_rc.return_value
 
         c = ClientGrants(domain='domain', token='jwttoken')
+
+        # With default params
         c.all()
 
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/client-grants', args[0])
-        self.assertEqual(kwargs['params'], {'audience': None})
+        self.assertEqual(kwargs['params'], {
+            'audience': None,
+            'per_page': 50,
+            'page': 0,
+            'include_totals': 'true'
+        })
 
-        c.all(audience="http://domain.auth0.com/api/v2/")
+        # With audience
+        c.all(audience='http://domain.auth0.com/api/v2/')
 
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/client-grants', args[0])
-        self.assertEqual(kwargs['params'], {'audience': 'http://domain.auth0.com/api/v2/'})
+        self.assertEqual(kwargs['params'], {
+            'audience': 'http://domain.auth0.com/api/v2/',
+            'per_page': 50,
+            'page': 0,
+            'include_totals': 'true'
+        })
+
+        # With pagination params
+        c.all(per_page=23, page=7, include_totals=False)
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/client-grants', args[0])
+        self.assertEqual(kwargs['params'], {
+            'audience': None,
+            'per_page': 23,
+            'page': 7,
+            'include_totals': 'false'
+        })
 
     @mock.patch('auth0.v3.management.client_grants.RestClient')
     def test_create(self, mock_rc):

--- a/auth0/v3/test/management/test_resource_servers.py
+++ b/auth0/v3/test/management/test_resource_servers.py
@@ -29,8 +29,8 @@ class TestResourceServers(unittest.TestCase):
         mock_instance.get.assert_called_with(
             'https://domain/api/v2/resource-servers',
             params={
-                'page': 0,
-                'per_page': 50,
+                'page': None,
+                'per_page': None,
                 'include_totals': 'false'
             }
         )

--- a/auth0/v3/test/management/test_resource_servers.py
+++ b/auth0/v3/test/management/test_resource_servers.py
@@ -23,10 +23,28 @@ class TestResourceServers(unittest.TestCase):
 
         r = ResourceServers(domain='domain', token='jwttoken')
 
+        # with default params
         r.get_all()
 
         mock_instance.get.assert_called_with(
-            'https://domain/api/v2/resource-servers'
+            'https://domain/api/v2/resource-servers',
+            params={
+                'page': 0,
+                'per_page': 50,
+                'include_totals': 'false'
+            }
+        )
+
+        # with pagination params
+        r.get_all(page=3, per_page=27, include_totals=True)
+
+        mock_instance.get.assert_called_with(
+            'https://domain/api/v2/resource-servers',
+            params={
+                'page': 3,
+                'per_page': 27,
+                'include_totals': 'true'
+            }
         )
 
     @mock.patch('auth0.v3.management.resource_servers.RestClient')

--- a/auth0/v3/test/management/test_rules.py
+++ b/auth0/v3/test/management/test_rules.py
@@ -10,6 +10,8 @@ class TestRules(unittest.TestCase):
         mock_instance = mock_rc.return_value
 
         c = Rules(domain='domain', token='jwttoken')
+
+        # with default params
         c.all()
 
         args, kwargs = mock_instance.get.call_args
@@ -18,8 +20,12 @@ class TestRules(unittest.TestCase):
         self.assertEqual(kwargs['params'], {'fields': None,
                                             'include_fields': 'true',
                                             'enabled': 'true',
-                                            'stage': 'login_success'})
+                                            'stage': 'login_success',
+                                            'page': None,
+                                            'per_page': None,
+                                            'include_totals': 'false'})
 
+        # with stage and fields params
         c.all(stage='stage', enabled=False, fields=['a', 'b'],
               include_fields=False)
 
@@ -29,17 +35,24 @@ class TestRules(unittest.TestCase):
         self.assertEqual(kwargs['params'], {'fields': 'a,b',
                                             'include_fields': 'false',
                                             'enabled': 'false',
-                                            'stage': 'stage'})
+                                            'stage': 'stage',
+                                            'page': None,
+                                            'per_page': None,
+                                            'include_totals': 'false'})
 
-        c.all(stage='stage', enabled=None, fields=['a', 'b'],
-              include_fields=False)
+        # with pagination params
+        c.all(page=3, per_page=27, include_totals=True)
 
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/rules', args[0])
-        self.assertEqual(kwargs['params'], {'fields': 'a,b',
-                                            'include_fields': 'false',
-                                            'stage': 'stage'})
+        self.assertEqual(kwargs['params'], {'fields': None,
+                                            'include_fields': 'true',
+                                            'enabled': 'true',
+                                            'stage': 'login_success',
+                                            'page': 3,
+                                            'per_page': 27,
+                                            'include_totals': 'true'})
 
     @mock.patch('auth0.v3.management.rules.RestClient')
     def test_create(self, mock_rc):


### PR DESCRIPTION
### What
This PR adds pagination support on MGMT API entities that were missing. 

I kept this free from breaking changes by providing an `include_totals=False` value (since if that's true, the response is an Object rather than an Array).

### Scope
- [x] Clients Grants
- [ ] User Grants (Missing entity, not going to be implemented)
- [x] Resource Servers
- [x] Rules

### How it was tested
✅ Unit tests asserting the params with which the function was called. Similar to the other pagination PR.

