### PR TITLE
Use README.rst as long_description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def find_version():
             raise RuntimeError("Unable to find version string.")
 
 
-with open('README.rst') as f:
+with io.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,15 @@ def find_version():
             raise RuntimeError("Unable to find version string.")
 
 
+with open('README.rst') as f:
+    long_description = f.read()
+
+
 setup(
     name='auth0-python',
     version=find_version(),
     description='Auth0 Python SDK',
+    long_description=long_description,
     author='Auth0',
     author_email='support@auth0.com',
     license='MIT',


### PR DESCRIPTION
Right now, https://pypi.org/project/auth0-python/ looks like:

![image](https://user-images.githubusercontent.com/1324225/46332340-c4f03900-c624-11e8-86c2-b460c5df6d95.png)

Instead of "The author of this package has not provided a project description", we can put the contents of the README there. This is what Python packages commonly do.