### PR TITLE
Correction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+WORKDIR /home/app
+
+ADD . /home/app
+ADD ./.pypirc ~/
+RUN cp /home/app/.pypirc ~
+
+CMD  python3 setup.py sdist bdist upload

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,0 @@
-FROM python:3
-
-WORKDIR /home/app
-
-ADD . /home/app
-ADD ./.pypirc ~/
-RUN cp /home/app/.pypirc ~
-
-CMD  python setup.py sdist bdist upload


### PR DESCRIPTION
Fixes #143 

The Dockerfile was earlier named `dockerfile`. In this PR, I've changed it to `Dockerfile`, according to the correct format and also made support for python3