### PR TITLE
add default timeout on requests

### DIFF
--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -10,11 +10,12 @@ class AuthenticationBase(object):
 
     def post(self, url, data=None, headers=None):
         response = requests.post(url=url, data=json.dumps(data),
-                                 headers=headers)
+                                 headers=headers, timeout=30)
         return self._process_response(response)
 
     def get(self, url, params=None, headers=None):
-        return requests.get(url=url, params=params, headers=headers).text
+        return requests.get(url=url, params=params, 
+                            headers=headers, timeout=30).text
 
     def _process_response(self, response):
         return self._parse(response).content()

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -16,7 +16,7 @@ class TestBase(unittest.TestCase):
         data = ab.post('the-url', data={'a': 'b'}, headers={'c': 'd'})
 
         mock_post.assert_called_with(url='the-url', data='{"a": "b"}',
-                                     headers={'c': 'd'})
+                                     headers={'c': 'd'}, timeout=30)
 
         self.assertEqual(data, {'x': 'y'})
 


### PR DESCRIPTION
to avoid hanging indefinitely as brought up by #82 

I chose 30 seconds because of [this comment](https://github.com/requests/requests/issues/3070#issuecomment-318949822) on the `requests` repo.

I'd like to try my hand at contributing to auth0 but I'm not quite sure where to go from here in regards to this PR.

**On the timeout value,**

1. should I add it as a config somehow, 
2. put it in as an optional parameter everywhere, 
3. or leave it as is?

**On the error thrown when timing out,**

1. should I catch the error and construct a fake 408 (Request Timeout) response, 
2. wrap requests' timeout error and toss that back, updating documentation as needed, 
3. or leave it as is?

Any feedback would be greatly appreciated!