### PR TITLE
Add telemetry headers to AuthenticationBase

### DIFF
--- a/auth0/v3/authentication/authorize_client.py
+++ b/auth0/v3/authentication/authorize_client.py
@@ -9,9 +9,6 @@ class AuthorizeClient(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def authorize(self, client_id, audience=None, state=None, redirect_uri=None,
                   response_type='code', scope='openid'):
         """Authorization code grant

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -18,7 +18,9 @@ class AuthenticationBase(object):
             (defaults to True)
     """
 
-    def __init__(self, telemetry=True):
+    def __init__(self, domain, telemetry=True):
+        self.domain = domain
+
         self.base_headers = {'Content-Type': 'application/json'}
 
         if telemetry:

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -1,4 +1,7 @@
+import base64
 import json
+import sys
+import platform
 import requests
 from ..exceptions import Auth0Error
 
@@ -8,13 +11,54 @@ UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
 
 class AuthenticationBase(object):
 
+    """Base authentication object providing simple REST methods.
+
+    Args:
+        telemetry (bool, optional): Enable or disable Telemetry
+            (defaults to True)
+    """
+
+    def __init__(self, telemetry=True):
+        self.base_headers = {'Content-Type': 'application/json'}
+
+        if telemetry:
+            py_version = platform.python_version()
+            version = sys.modules['auth0'].__version__
+
+            auth0_client = json.dumps({
+                'name': 'auth0-python',
+                'version': version,
+                'dependencies': [
+                    {
+                        'name': 'requests',
+                        'version': requests.__version__,
+                    }
+                ],
+                'environment': [
+                    {
+                        'name': 'python',
+                        'version': py_version,
+                    }
+                ]
+            }).encode('utf-8')
+
+            self.base_headers.update({
+                'User-Agent': 'Python/%s' % py_version,
+                'Auth0-Client': base64.b64encode(auth0_client),
+            })
+
     def post(self, url, data=None, headers=None):
+        request_headers = self.base_headers.copy()
+        request_headers.update(headers)
         response = requests.post(url=url, data=json.dumps(data),
-                                 headers=headers)
+                                 headers=request_headers)
         return self._process_response(response)
 
     def get(self, url, params=None, headers=None):
-        return requests.get(url=url, params=params, headers=headers).text
+        request_headers = self.base_headers.copy()
+        request_headers.update(headers)
+        response = requests.get(url=url, params=params, headers=request_headers)
+        return response.text
 
     def _process_response(self, response):
         return self._parse(response).content()

--- a/auth0/v3/authentication/database.py
+++ b/auth0/v3/authentication/database.py
@@ -10,9 +10,6 @@ class Database(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def login(self, client_id, username, password, connection, id_token=None,
               grant_type='password', device=None, scope='openid'):
         """Login using username and password

--- a/auth0/v3/authentication/delegated.py
+++ b/auth0/v3/authentication/delegated.py
@@ -9,9 +9,6 @@ class Delegated(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def get_token(self, client_id, target, api_type, grant_type,
                   id_token=None, refresh_token=None, scope='openid'):
 

--- a/auth0/v3/authentication/enterprise.py
+++ b/auth0/v3/authentication/enterprise.py
@@ -9,9 +9,6 @@ class Enterprise(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def saml_metadata(self, client_id):
         """Get SAML2.0 Metadata.
 

--- a/auth0/v3/authentication/get_token.py
+++ b/auth0/v3/authentication/get_token.py
@@ -9,9 +9,6 @@ class GetToken(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def authorization_code(self, client_id, client_secret, code,
                            redirect_uri, grant_type='authorization_code'):
         """Authorization code grant

--- a/auth0/v3/authentication/logout.py
+++ b/auth0/v3/authentication/logout.py
@@ -13,9 +13,6 @@ class Logout(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def logout(self, client_id, return_to, federated=False):
         """Logout
 

--- a/auth0/v3/authentication/passwordless.py
+++ b/auth0/v3/authentication/passwordless.py
@@ -9,9 +9,6 @@ class Passwordless(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def email(self, client_id, email, send='link', auth_params=None):
         """Start flow sending an email.
 

--- a/auth0/v3/authentication/social.py
+++ b/auth0/v3/authentication/social.py
@@ -9,9 +9,6 @@ class Social(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def login(self, client_id, access_token, connection, scope='openid'):
         """Login using a social provider's access token
 

--- a/auth0/v3/authentication/users.py
+++ b/auth0/v3/authentication/users.py
@@ -10,9 +10,6 @@ class Users(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def __init__(self, domain):
-        self.domain = domain
-
     def userinfo(self, access_token):
 
         """Returns the user information based on the Auth0 access token.

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -1,14 +1,57 @@
-import unittest
+import base64
+import json
 import mock
+import sys
+import requests
+import unittest
 from ...authentication.base import AuthenticationBase
 from ...exceptions import Auth0Error
 
 
 class TestBase(unittest.TestCase):
 
+    def test_telemetry_enabled_by_default(self):
+        ab = AuthenticationBase()
+
+        user_agent = ab.base_headers['User-Agent']
+        auth0_client_bytes = base64.b64decode(ab.base_headers['Auth0-Client'])
+        auth0_client_json = auth0_client_bytes.decode('utf-8')
+        auth0_client = json.loads(auth0_client_json)
+        content_type = ab.base_headers['Content-Type']
+
+        from auth0 import __version__ as auth0_version
+        python_version = '{}.{}.{}'.format(sys.version_info.major,
+                                           sys.version_info.minor,
+                                           sys.version_info.micro)
+
+        client_info = {
+            'name': 'auth0-python', 'version': auth0_version,
+            'dependencies': [
+                {
+                    'name': 'requests',
+                    'version': requests.__version__
+                }
+            ],
+            'environment': [
+                {
+                    'name': 'python',
+                    'version': python_version
+                }
+            ]
+        }
+
+        self.assertEqual(user_agent, 'Python/{}'.format(python_version))
+        self.assertEqual(auth0_client, client_info)
+        self.assertEqual(content_type, 'application/json')
+
+    def test_telemetry_disabled(self):
+        ab = AuthenticationBase(telemetry=False)
+
+        self.assertEqual(ab.base_headers, {'Content-Type': 'application/json'})
+
     @mock.patch('requests.post')
     def test_post(self, mock_post):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase(telemetry=False)
 
         mock_post.return_value.status_code = 200
         mock_post.return_value.text = '{"x": "y"}'
@@ -16,13 +59,34 @@ class TestBase(unittest.TestCase):
         data = ab.post('the-url', data={'a': 'b'}, headers={'c': 'd'})
 
         mock_post.assert_called_with(url='the-url', data='{"a": "b"}',
-                                     headers={'c': 'd'})
+                headers={'c': 'd', 'Content-Type': 'application/json'})
+
+        self.assertEqual(data, {'x': 'y'})
+
+    @mock.patch('requests.post')
+    def test_post_includes_telemetry(self, mock_post):
+        ab = AuthenticationBase()
+
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.text = '{"x": "y"}'
+
+        data = ab.post('the-url', data={'a': 'b'}, headers={'c': 'd'})
+
+        self.assertEqual(mock_post.call_count, 1)
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(call_kwargs['url'], 'the-url')
+        self.assertEqual(call_kwargs['data'], '{"a": "b"}')
+        headers = call_kwargs['headers']
+        self.assertEqual(headers['c'], 'd')
+        self.assertEqual(headers['Content-Type'], 'application/json')
+        self.assertIn('User-Agent', headers)
+        self.assertIn('Auth0-Client', headers)
 
         self.assertEqual(data, {'x': 'y'})
 
     @mock.patch('requests.post')
     def test_post_error(self, mock_post):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase(telemetry=False)
 
         for error_status in [400, 500, None]:
             mock_post.return_value.status_code = error_status
@@ -100,3 +164,24 @@ class TestBase(unittest.TestCase):
             self.assertEqual(context.exception.error_code,
                              'a0.sdk.internal.unknown')
             self.assertEqual(context.exception.message, '')
+
+    @mock.patch('requests.get')
+    def test_get_includes_telemetry(self, mock_get):
+        ab = AuthenticationBase()
+
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.text = '{"x": "y"}'
+
+        data = ab.get('the-url', params={'a': 'b'}, headers={'c': 'd'})
+
+        self.assertEqual(mock_get.call_count, 1)
+        call_kwargs = mock_get.call_args[1]
+        self.assertEqual(call_kwargs['url'], 'the-url')
+        self.assertEqual(call_kwargs['params'], {'a': 'b'})
+        headers = call_kwargs['headers']
+        self.assertEqual(headers['c'], 'd')
+        self.assertEqual(headers['Content-Type'], 'application/json')
+        self.assertIn('User-Agent', headers)
+        self.assertIn('Auth0-Client', headers)
+
+        self.assertEqual(data, '{"x": "y"}')

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -11,7 +11,7 @@ from ...exceptions import Auth0Error
 class TestBase(unittest.TestCase):
 
     def test_telemetry_enabled_by_default(self):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase('auth0.com')
 
         user_agent = ab.base_headers['User-Agent']
         auth0_client_bytes = base64.b64decode(ab.base_headers['Auth0-Client'])
@@ -45,13 +45,13 @@ class TestBase(unittest.TestCase):
         self.assertEqual(content_type, 'application/json')
 
     def test_telemetry_disabled(self):
-        ab = AuthenticationBase(telemetry=False)
+        ab = AuthenticationBase('auth0.com', telemetry=False)
 
         self.assertEqual(ab.base_headers, {'Content-Type': 'application/json'})
 
     @mock.patch('requests.post')
     def test_post(self, mock_post):
-        ab = AuthenticationBase(telemetry=False)
+        ab = AuthenticationBase('auth0.com', telemetry=False)
 
         mock_post.return_value.status_code = 200
         mock_post.return_value.text = '{"x": "y"}'
@@ -65,7 +65,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.post')
     def test_post_includes_telemetry(self, mock_post):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase('auth0.com')
 
         mock_post.return_value.status_code = 200
         mock_post.return_value.text = '{"x": "y"}'
@@ -86,7 +86,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.post')
     def test_post_error(self, mock_post):
-        ab = AuthenticationBase(telemetry=False)
+        ab = AuthenticationBase('auth0.com', telemetry=False)
 
         for error_status in [400, 500, None]:
             mock_post.return_value.status_code = error_status
@@ -102,7 +102,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.post')
     def test_post_error_with_code_property(self, mock_post):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase('auth0.com', telemetry=False)
 
         for error_status in [400, 500, None]:
             mock_post.return_value.status_code = error_status
@@ -118,7 +118,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.post')
     def test_post_error_with_no_error_code(self, mock_post):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase('auth0.com', telemetry=False)
 
         for error_status in [400, 500, None]:
             mock_post.return_value.status_code = error_status
@@ -134,7 +134,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.post')
     def test_post_error_with_text_response(self, mock_post):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase('auth0.com', telemetry=False)
 
         for error_status in [400, 500, None]:
             mock_post.return_value.status_code = error_status
@@ -151,7 +151,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.post')
     def test_post_error_with_no_response_text(self, mock_post):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase('auth0.com', telemetry=False)
 
         for error_status in [400, 500, None]:
             mock_post.return_value.status_code = error_status
@@ -167,7 +167,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.get')
     def test_get_includes_telemetry(self, mock_get):
-        ab = AuthenticationBase()
+        ab = AuthenticationBase('auth0.com')
 
         mock_get.return_value.status_code = 200
         mock_get.return_value.text = '{"x": "y"}'


### PR DESCRIPTION
Added a `telemetry` kwarg to the `AuthenticationBase` constructor and (mostly) matched the telemetry behavior from the management `RestClient` class.

fixes #136