### PR TITLE
Used COPY instead of ADD.

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,8 +2,8 @@ FROM python:3
 
 WORKDIR /home/app
 
-ADD . /home/app
-ADD ./.pypirc ~/
+COPY . /home/app
+COPY ./.pypirc ~/
 RUN cp /home/app/.pypirc ~
 
 CMD  python setup.py sdist bdist upload


### PR DESCRIPTION
The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).