### PR TITLE
Fix EOL hyperlink in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ For python3, use the following command
     
     pip3 install auth0-python
 
-Python 3.2 and 3.3 have reached `end-of-life<https://en.wikipedia.org/wiki/CPython#Version_history>`_ and support will be removed in the near future.
+Python 3.2 and 3.3 have reached `EOL <https://en.wikipedia.org/wiki/CPython#Version_history>`_ and support will be removed in the near future.
 
 ====================
 Management SDK Usage


### PR DESCRIPTION
I accidentally force pushed without making the new commit and Github closed the pull request [https://github.com/auth0/auth0-python/pull/157]. New pushes aren't updating the PR for me, so creating this new one. 

Changed the text from `end-of-life` to `EOL` because `-` was messing up the markup rendering. 

See : https://github.com/auth0/auth0-python/pull/157#pullrequestreview-171707418