### PR TITLE
Stop lower-casing email on user search

### DIFF
--- a/auth0/v3/management/users_by_email.py
+++ b/auth0/v3/management/users_by_email.py
@@ -39,7 +39,7 @@ class UsersByEmail(object):
         See: https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email
         """
         params = {
-            'email': email.lower(),
+            'email': email,
             'fields': fields and ','.join(fields) or None,
             'include_fields': str(include_fields).lower()
         }

--- a/auth0/v3/test/management/test_users_by_email.py
+++ b/auth0/v3/test/management/test_users_by_email.py
@@ -16,7 +16,7 @@ class TestUsersByEmail(unittest.TestCase):
 
         self.assertEqual('https://domain/api/v2/users-by-email', args[0])
         self.assertEqual(kwargs['params'], {
-            'email': 'a@b.com',
+            'email': 'A@B.com',
             'fields': None,
             'include_fields': 'true'
         })


### PR DESCRIPTION
Per the documentation here:
https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email

> If Auth0 is the identify provider (idP), the email address associated with a user is saved in lower case, regardless of how you initially provided it. For example, if you register a user as JohnSmith@example.com, Auth0 saves the user's email as johnsmith@example.com.
> 
> **In cases where Auth0 is not the idP, the `email` is stored based on the rules of idP, so make sure the search is made using the correct capitalization.**