### PR TITLE
Remove default value for search_engine

### DIFF
--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -25,7 +25,7 @@ class Users(object):
         return url
 
     def list(self, page=0, per_page=25, sort=None, connection=None, q=None,
-             search_engine='v1', include_totals=True, fields=None,
+             search_engine=None, include_totals=True, fields=None,
              include_fields=True):
         """List or search users.
 
@@ -43,8 +43,9 @@ class Users(object):
                 in app_metadata, user_metadata or the normalized user profile
                 are searchable.
 
-            search_engine (str, optional): Use 'v2' if you want to try our new
-                search engine.
+            search_engine (str, optional): The version of the search_engine to use
+                when querying for users. Will default to the latest version available.
+                See: https://auth0.com/docs/users/search
 
             fields (list of str, optional): A list of fields to include or
                 exclude from the result (depending on include_fields). Empty to

--- a/auth0/v3/test/management/test_users.py
+++ b/auth0/v3/test/management/test_users.py
@@ -24,7 +24,7 @@ class TestUsers(unittest.TestCase):
             'fields': None,
             'include_fields': 'true',
             'q': None,
-            'search_engine': 'v1'
+            'search_engine': None
         })
 
         u.list(page=1, per_page=50, sort='s', connection='con', q='q',


### PR DESCRIPTION
### Changes

Search engine v2 is no longer available for new tenants. This caused frustration for those using this library without passing a specific value for the `search_engine` feature when querying for users.

This PR removes the default value of `v1` (even older, and already disabled a long time ago). This way, those not specifying a value will default to the backend's latest version. Currently v3.

Those already passing a fixed value will see no effect.

### References

> User search v2 has been deprecated as of June 6th 2018. Tenants created after this date will not have the option of using it. We recommend that you use User Search v3 instead.

https://auth0.com/docs/users/search/v2
https://auth0.com/docs/users/search/v3

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
