### PR TITLE
Fix HTTP method used for rotating Client secret

### DIFF
--- a/auth0/v3/management/clients.py
+++ b/auth0/v3/management/clients.py
@@ -129,7 +129,7 @@ class Clients(object):
               See: https://auth0.com/docs/api/management/v2#!/Clients/post_rotate_secret
         """
 
-        params = {'id': id }
+        data = {'id': id }
 
         url = self._url('%s/rotate-secret' % id)
-        return self.client.get(url, params=params)
+        return self.client.post(url, data=data)

--- a/auth0/v3/test/management/test_clients.py
+++ b/auth0/v3/test/management/test_clients.py
@@ -119,8 +119,8 @@ class TestClients(unittest.TestCase):
         c = Clients(domain='domain', token='jwttoken')
         c.rotate_secret('this-id')
 
-        mock_instance.get.assert_called_with(
-            'https://domain/api/v2/clients/this-id/rotate-secret', params={'id': 'this-id'}
+        mock_instance.post.assert_called_with(
+            'https://domain/api/v2/clients/this-id/rotate-secret', data={'id': 'this-id'}
         )
 
 


### PR DESCRIPTION
### Changes

The rotate client secret endpoint expects a POST request, not a GET. This PR fixes it.

### References

Will close https://github.com/auth0/auth0-python/issues/189

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
