### PR TITLE
rules_config.unset fix

### DIFF
--- a/auth0/v3/management/rules_configs.py
+++ b/auth0/v3/management/rules_configs.py
@@ -39,10 +39,7 @@ class RulesConfigs(object):
 
         See: https://auth0.com/docs/api/management/v2#!/Rules_Configs/delete_rules_configs_by_key
         """
-        params = {
-            'key': key
-        }
-        return self.client.delete(self._url(), params=params)
+        return self.client.delete(self._url(key))
 
     def set(self, key, value):
         """Sets the rules config for a given key.

--- a/auth0/v3/test/management/test_rules_configs.py
+++ b/auth0/v3/test/management/test_rules_configs.py
@@ -25,7 +25,7 @@ class TestRules(unittest.TestCase):
         c.unset('an-id')
 
         mock_instance.delete.assert_called_with(
-            'https://domain/api/v2/rules-configs', params={'key': 'an-id'}
+            'https://domain/api/v2/rules-configs/an-id'
         )
 
     @mock.patch('auth0.v3.management.rules_configs.RestClient')


### PR DESCRIPTION
### Changes
Changes `rules_config.unset` to pass the `key` param as a path param instead of a query param. This fixes the 404 error previously being returned.

### References

Closes #194 

### Testing

Fixed existing unittest.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
