### PR TITLE
Add default timeout

### DIFF
--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -18,9 +18,9 @@ class AuthenticationBase(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, telemetry=True):
+    def __init__(self, domain, telemetry=True, timeout=5.0):
         self.domain = domain
-
+        self.timeout = timeout
         self.base_headers = {'Content-Type': 'application/json'}
 
         if telemetry:
@@ -43,13 +43,13 @@ class AuthenticationBase(object):
     def post(self, url, data=None, headers=None):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
-        response = requests.post(url=url, json=data, headers=request_headers)
+        response = requests.post(url=url, json=data, headers=request_headers, timeout=self.timeout)
         return self._process_response(response)
 
     def get(self, url, params=None, headers=None):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
-        response = requests.get(url=url, params=params, headers=request_headers)
+        response = requests.get(url=url, params=params, headers=request_headers, timeout=self.timeout)
         return self._process_response(response)
 
     def _process_response(self, response):

--- a/auth0/v3/management/blacklists.py
+++ b/auth0/v3/management/blacklists.py
@@ -13,9 +13,9 @@ class Blacklists(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.url = 'https://{}/api/v2/blacklists/tokens'.format(domain)
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def get(self, aud=None):
         """Retrieves the jti and aud of all tokens in the blacklist.

--- a/auth0/v3/management/client_grants.py
+++ b/auth0/v3/management/client_grants.py
@@ -14,9 +14,9 @@ class ClientGrants(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/client-grants'.format(self.domain)

--- a/auth0/v3/management/clients.py
+++ b/auth0/v3/management/clients.py
@@ -14,9 +14,9 @@ class Clients(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/clients'.format(self.domain)

--- a/auth0/v3/management/connections.py
+++ b/auth0/v3/management/connections.py
@@ -13,9 +13,9 @@ class Connections(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/connections'.format(self.domain)

--- a/auth0/v3/management/custom_domains.py
+++ b/auth0/v3/management/custom_domains.py
@@ -14,9 +14,9 @@ class CustomDomains(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://%s/api/v2/custom-domains' % self.domain

--- a/auth0/v3/management/device_credentials.py
+++ b/auth0/v3/management/device_credentials.py
@@ -14,9 +14,9 @@ class DeviceCredentials(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/device-credentials'.format(self.domain)

--- a/auth0/v3/management/email_templates.py
+++ b/auth0/v3/management/email_templates.py
@@ -14,9 +14,9 @@ class EmailTemplates(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/email-templates'.format(self.domain)

--- a/auth0/v3/management/emails.py
+++ b/auth0/v3/management/emails.py
@@ -14,9 +14,9 @@ class Emails(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/emails/provider'.format(self.domain)

--- a/auth0/v3/management/grants.py
+++ b/auth0/v3/management/grants.py
@@ -14,9 +14,9 @@ class Grants(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://%s/api/v2/grants' % self.domain

--- a/auth0/v3/management/guardian.py
+++ b/auth0/v3/management/guardian.py
@@ -14,9 +14,9 @@ class Guardian(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/guardian'.format(self.domain)

--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -14,9 +14,9 @@ class Jobs(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, path=None):
         url = 'https://{}/api/v2/jobs'.format(self.domain)

--- a/auth0/v3/management/logs.py
+++ b/auth0/v3/management/logs.py
@@ -14,9 +14,9 @@ class Logs(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/logs'.format(self.domain)

--- a/auth0/v3/management/resource_servers.py
+++ b/auth0/v3/management/resource_servers.py
@@ -14,9 +14,9 @@ class ResourceServers(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/resource-servers'.format(self.domain)

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -13,8 +13,9 @@ class RestClient(object):
 
     """Provides simple methods for handling all RESTful api endpoints. """
 
-    def __init__(self, jwt, telemetry=True):
+    def __init__(self, jwt, telemetry=True, timeout=5.0):
         self.jwt = jwt
+        self.timeout = timeout
 
         self.base_headers = {
             'Authorization': 'Bearer {}'.format(self.jwt),
@@ -40,38 +41,38 @@ class RestClient(object):
     def get(self, url, params=None):
         headers = self.base_headers.copy()
 
-        response = requests.get(url, params=params, headers=headers)
+        response = requests.get(url, params=params, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def post(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.post(url, json=data, headers=headers)
+        response = requests.post(url, json=data, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def file_post(self, url, data=None, files=None):
         headers = self.base_headers.copy()
         headers.pop('Content-Type', None)
 
-        response = requests.post(url, data=data, files=files, headers=headers)
+        response = requests.post(url, data=data, files=files, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def patch(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.patch(url, json=data, headers=headers)
+        response = requests.patch(url, json=data, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def put(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.put(url, json=data, headers=headers)
+        response = requests.put(url, json=data, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def delete(self, url, params=None, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.delete(url, headers=headers, params=params or {}, json=data)
+        response = requests.delete(url, headers=headers, params=params or {}, json=data, timeout=self.timeout)
         return self._process_response(response)
 
     def _process_response(self, response):

--- a/auth0/v3/management/roles.py
+++ b/auth0/v3/management/roles.py
@@ -14,9 +14,9 @@ class Roles(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/roles'.format(self.domain)

--- a/auth0/v3/management/rules.py
+++ b/auth0/v3/management/rules.py
@@ -14,9 +14,9 @@ class Rules(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/rules'.format(self.domain)

--- a/auth0/v3/management/rules_configs.py
+++ b/auth0/v3/management/rules_configs.py
@@ -14,9 +14,9 @@ class RulesConfigs(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://%s/api/v2/rules-configs' % self.domain

--- a/auth0/v3/management/stats.py
+++ b/auth0/v3/management/stats.py
@@ -13,9 +13,9 @@ class Stats(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, action):
         return 'https://{}/api/v2/stats/{}'.format(self.domain, action)

--- a/auth0/v3/management/tenants.py
+++ b/auth0/v3/management/tenants.py
@@ -14,9 +14,9 @@ class Tenants(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self):
         return 'https://{}/api/v2/tenants/settings'.format(self.domain)

--- a/auth0/v3/management/tickets.py
+++ b/auth0/v3/management/tickets.py
@@ -14,9 +14,9 @@ class Tickets(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, action):
         return 'https://{}/api/v2/tickets/{}'.format(self.domain, action)

--- a/auth0/v3/management/user_blocks.py
+++ b/auth0/v3/management/user_blocks.py
@@ -14,9 +14,9 @@ class UserBlocks(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/user-blocks'.format(self.domain)

--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -14,9 +14,9 @@ class Users(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/users'.format(self.domain)

--- a/auth0/v3/management/users_by_email.py
+++ b/auth0/v3/management/users_by_email.py
@@ -14,9 +14,9 @@ class UsersByEmail(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self):
         url = 'https://{}/api/v2/users-by-email'.format(self.domain)

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -51,7 +51,7 @@ class TestBase(unittest.TestCase):
         data = ab.post('the-url', data={'a': 'b'}, headers={'c': 'd'})
 
         mock_post.assert_called_with(url='the-url', json={'a': 'b'},
-                headers={'c': 'd', 'Content-Type': 'application/json'})
+                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
         
@@ -66,7 +66,7 @@ class TestBase(unittest.TestCase):
         data = ab.post('the-url')
 
         mock_post.assert_called_with(url='the-url', json=None,
-                headers={'Content-Type': 'application/json'})
+                headers={'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
 
@@ -182,7 +182,7 @@ class TestBase(unittest.TestCase):
         data = ab.get('the-url', params={'a': 'b'}, headers={'c': 'd'})
 
         mock_get.assert_called_with(url='the-url', params={'a': 'b'},
-                headers={'c': 'd', 'Content-Type': 'application/json'})
+                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
 
@@ -197,7 +197,7 @@ class TestBase(unittest.TestCase):
         data = ab.get('the-url')
 
         mock_get.assert_called_with(url='the-url', params=None,
-                headers={'Content-Type': 'application/json'})
+                headers={'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
 
@@ -221,3 +221,15 @@ class TestBase(unittest.TestCase):
         self.assertIn('Auth0-Client', headers)
 
         self.assertEqual(data, {"x": "y"})
+
+    def test_get_can_timeout(self):
+        ab = AuthenticationBase('auth0.com', timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            ab.get('https://auth0.com', params={'a': 'b'}, headers={'c': 'd'})
+
+    def test_post_can_timeout(self):
+        ab = AuthenticationBase('auth0.com', timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            ab.post('https://auth0.com', data={'a': 'b'}, headers={'c': 'd'})

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -22,14 +22,14 @@ class TestRest(unittest.TestCase):
         mock_get.return_value.status_code = 200
 
         response = rc.get('the-url')
-        mock_get.assert_called_with('the-url', params=None, headers=headers)
+        mock_get.assert_called_with('the-url', params=None, headers=headers, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
         response = rc.get(url='the/url', params={'A': 'param', 'B': 'param'})
         mock_get.assert_called_with('the/url', params={'A': 'param',
                                                        'B': 'param'},
-                                    headers=headers)
+                                    headers=headers, timeout=5.0)
         self.assertEqual(response, ['a', 'b'])
 
         mock_get.return_value.text = ''
@@ -65,7 +65,7 @@ class TestRest(unittest.TestCase):
         mock_post.return_value.status_code = 200
         response = rc.post('the/url', data=data)
         mock_post.assert_called_with('the/url', json=data,
-                                     headers=headers)
+                                     headers=headers, timeout=5.0)
 
         self.assertEqual(response, {'a': 'b'})
 
@@ -213,7 +213,7 @@ class TestRest(unittest.TestCase):
 
         rc.file_post('the-url', data=data, files=files)
 
-        mock_post.assert_called_once_with('the-url', data=data, files=files, headers=headers)
+        mock_post.assert_called_once_with('the-url', data=data, files=files, headers=headers, timeout=5.0)
 
 
     @mock.patch('requests.put')
@@ -229,7 +229,7 @@ class TestRest(unittest.TestCase):
 
         response = rc.put(url='the-url', data=data)
         mock_put.assert_called_with('the-url', json=data,
-                                      headers=headers)
+                                      headers=headers, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
@@ -262,7 +262,7 @@ class TestRest(unittest.TestCase):
 
         response = rc.patch(url='the-url', data=data)
         mock_patch.assert_called_with('the-url', json=data,
-                                      headers=headers)
+                                      headers=headers, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
@@ -294,7 +294,7 @@ class TestRest(unittest.TestCase):
         mock_delete.return_value.status_code = 200
 
         response = rc.delete(url='the-url/ID')
-        mock_delete.assert_called_with('the-url/ID', headers=headers, params={}, json=None)
+        mock_delete.assert_called_with('the-url/ID', headers=headers, params={}, json=None, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
@@ -313,7 +313,7 @@ class TestRest(unittest.TestCase):
         params={'A': 'param', 'B': 'param'}
 
         response = rc.delete(url='the-url/ID', params=params, data=data)
-        mock_delete.assert_called_with('the-url/ID', headers=headers, params=params, json=data)
+        mock_delete.assert_called_with('the-url/ID', headers=headers, params=params, json=data, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 


### PR DESCRIPTION
### Changes
This PR is an updated version of #148.
I decided for 5s, because 30s seems excessive to me (especially in the context of a sync web server), feel free to disagree.

### References
Having no timeout is never a good idea in prod. Auth0 might have issues and we don't want to hang our python server because of that.

### Testing
- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version

### Checklist
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
