### PR TITLE
Accept client_secret as passwordless/start param

### DIFF
--- a/auth0/v3/authentication/passwordless.py
+++ b/auth0/v3/authentication/passwordless.py
@@ -9,7 +9,7 @@ class Passwordless(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def email(self, client_id, email, send='link', auth_params=None):
+    def email(self, client_id, email, send='link', auth_params=None, client_secret=None):
         """Start flow sending an email.
 
         Given the user email address, it will send an email with:
@@ -31,12 +31,15 @@ class Passwordless(AuthenticationBase):
             send (str, optional): Can be: 'link' or 'code'. Defaults to 'link'.
 
             auth_params (dict, optional): Parameters to append or override.
+
+            client_secret (str): Client Secret of the application.
         """
 
         return self.post(
             'https://{}/passwordless/start'.format(self.domain),
             data={
                 'client_id': client_id,
+                'client_secret': client_secret,
                 'connection': 'email',
                 'email': email,
                 'send': send,
@@ -44,14 +47,26 @@ class Passwordless(AuthenticationBase):
             }
         )
 
-    def sms(self, client_id, phone_number):
-        """Start flow sending a SMS message.
+    def sms(self, client_id, phone_number, client_secret=None):
+        """Start flow sending an SMS message.
+
+        Given the user phone number, it will send an SMS with 
+        a verification code. You can then authenticate with
+        this user using phone number as username and code as password.
+
+        Args:
+            client_id (str): Client Id of the application.
+
+            client_secret (str): Client Secret of the application.
+
+            phone_number (str): Phone number.
         """
 
         return self.post(
             'https://{}/passwordless/start'.format(self.domain),
             data={
                 'client_id': client_id,
+                'client_secret': client_secret,
                 'connection': 'sms',
                 'phone_number': phone_number,
             }
@@ -59,6 +74,15 @@ class Passwordless(AuthenticationBase):
 
     def sms_login(self, client_id, phone_number, code, scope='openid'):
         """Login using phone number/verification code.
+
+        Args:
+            client_id (str): Client Id of the application.
+
+            phone_number (str): Phone number.
+
+            code (str): Code received in the SMS.
+
+            scope (str, optional): Scope to use. Defaults to 'openid'.
         """
 
         return self.post(

--- a/auth0/v3/authentication/passwordless.py
+++ b/auth0/v3/authentication/passwordless.py
@@ -35,16 +35,20 @@ class Passwordless(AuthenticationBase):
             client_secret (str): Client Secret of the application.
         """
 
+        data={
+            'client_id': client_id,
+            'connection': 'email',
+            'email': email,
+            'send': send,
+        }
+        if auth_params:
+            data.update({'authParams': auth_params})
+        if client_secret:
+            data.update({'client_secret': client_secret})
+
         return self.post(
             'https://{}/passwordless/start'.format(self.domain),
-            data={
-                'client_id': client_id,
-                'client_secret': client_secret,
-                'connection': 'email',
-                'email': email,
-                'send': send,
-                'authParams': auth_params
-            }
+            data=data
         )
 
     def sms(self, client_id, phone_number, client_secret=None):
@@ -62,14 +66,17 @@ class Passwordless(AuthenticationBase):
             phone_number (str): Phone number.
         """
 
+        data={
+            'client_id': client_id,
+            'connection': 'sms',
+            'phone_number': phone_number,
+        }
+        if client_secret:
+            data.update({'client_secret': client_secret})
+            
         return self.post(
             'https://{}/passwordless/start'.format(self.domain),
-            data={
-                'client_id': client_id,
-                'client_secret': client_secret,
-                'connection': 'sms',
-                'phone_number': phone_number,
-            }
+            data=data
         )
 
     def sms_login(self, client_id, phone_number, code, scope='openid'):

--- a/auth0/v3/test/authentication/test_passwordless.py
+++ b/auth0/v3/test/authentication/test_passwordless.py
@@ -12,28 +12,24 @@ class TestPasswordless(unittest.TestCase):
 
         p.email(client_id='cid',
                 email='a@b.com',
-                send='snd',
-                auth_params={'a': 'b'})
+                send='snd')
 
         args, kwargs = mock_post.call_args
 
         self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
         self.assertEqual(kwargs['data'], {
             'client_id': 'cid',
-            'client_secret': None,
             'email': 'a@b.com',
             'send': 'snd',
-            'authParams': {'a': 'b'},
             'connection': 'email',
         })
 
     @mock.patch('auth0.v3.authentication.passwordless.Passwordless.post')
-    def test_email_with_secret(self, mock_post):
+    def test_email_with_auth_params(self, mock_post):
 
         p = Passwordless('my.domain.com')
 
         p.email(client_id='cid',
-                client_secret='csecret',
                 email='a@b.com',
                 send='snd',
                 auth_params={'a': 'b'})
@@ -43,10 +39,30 @@ class TestPasswordless(unittest.TestCase):
         self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
         self.assertEqual(kwargs['data'], {
             'client_id': 'cid',
-            'client_secret': 'csecret',
             'email': 'a@b.com',
             'send': 'snd',
             'authParams': {'a': 'b'},
+            'connection': 'email',
+        })
+
+    @mock.patch('auth0.v3.authentication.passwordless.Passwordless.post')
+    def test_email_with_client_secret(self, mock_post):
+
+        p = Passwordless('my.domain.com')
+
+        p.email(client_id='cid',
+                client_secret='csecret',
+                email='a@b.com',
+                send='snd')
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
+        self.assertEqual(kwargs['data'], {
+            'client_id': 'cid',
+            'client_secret': 'csecret',
+            'email': 'a@b.com',
+            'send': 'snd',
             'connection': 'email',
         })
 
@@ -61,13 +77,12 @@ class TestPasswordless(unittest.TestCase):
         self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
         self.assertEqual(kwargs['data'], {
             'client_id': 'cid',
-            'client_secret': None,
             'phone_number': '123456',
             'connection': 'sms',
         })
 
     @mock.patch('auth0.v3.authentication.passwordless.Passwordless.post')
-    def test_sms_with_secret(self, mock_post):
+    def test_sms_with_client_secret(self, mock_post):
         p = Passwordless('my.domain.com')
 
         p.sms(client_id='cid', client_secret='csecret', phone_number='123456')

--- a/auth0/v3/test/authentication/test_passwordless.py
+++ b/auth0/v3/test/authentication/test_passwordless.py
@@ -20,6 +20,30 @@ class TestPasswordless(unittest.TestCase):
         self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
         self.assertEqual(kwargs['data'], {
             'client_id': 'cid',
+            'client_secret': None,
+            'email': 'a@b.com',
+            'send': 'snd',
+            'authParams': {'a': 'b'},
+            'connection': 'email',
+        })
+
+    @mock.patch('auth0.v3.authentication.passwordless.Passwordless.post')
+    def test_email_with_secret(self, mock_post):
+
+        p = Passwordless('my.domain.com')
+
+        p.email(client_id='cid',
+                client_secret='csecret',
+                email='a@b.com',
+                send='snd',
+                auth_params={'a': 'b'})
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
+        self.assertEqual(kwargs['data'], {
+            'client_id': 'cid',
+            'client_secret': 'csecret',
             'email': 'a@b.com',
             'send': 'snd',
             'authParams': {'a': 'b'},
@@ -37,6 +61,23 @@ class TestPasswordless(unittest.TestCase):
         self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
         self.assertEqual(kwargs['data'], {
             'client_id': 'cid',
+            'client_secret': None,
+            'phone_number': '123456',
+            'connection': 'sms',
+        })
+
+    @mock.patch('auth0.v3.authentication.passwordless.Passwordless.post')
+    def test_sms_with_secret(self, mock_post):
+        p = Passwordless('my.domain.com')
+
+        p.sms(client_id='cid', client_secret='csecret', phone_number='123456')
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], 'https://my.domain.com/passwordless/start')
+        self.assertEqual(kwargs['data'], {
+            'client_id': 'cid',
+            'client_secret': 'csecret',
             'phone_number': '123456',
             'connection': 'sms',
         })


### PR DESCRIPTION
### Changes

Tenants created after January 2, 2020 are required to set the client_secret when starting the passwordless flow.

### References

API docs https://auth0.com/docs/api/authentication?#get-code-or-link
Migration guide: https://auth0.com/docs/migrations/guides/passwordless-start

### Testing

Added tests for the optional parameter

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
