### PR TITLE
Add connect/read timeout option

### DIFF
--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -18,9 +18,9 @@ class AuthenticationBase(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, telemetry=True):
+    def __init__(self, domain, telemetry=True, timeout=5.0):
         self.domain = domain
-
+        self.timeout = timeout
         self.base_headers = {'Content-Type': 'application/json'}
 
         if telemetry:
@@ -43,13 +43,13 @@ class AuthenticationBase(object):
     def post(self, url, data=None, headers=None):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
-        response = requests.post(url=url, json=data, headers=request_headers)
+        response = requests.post(url=url, json=data, headers=request_headers, timeout=self.timeout)
         return self._process_response(response)
 
     def get(self, url, params=None, headers=None):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
-        response = requests.get(url=url, params=params, headers=request_headers)
+        response = requests.get(url=url, params=params, headers=request_headers, timeout=self.timeout)
         return self._process_response(response)
 
     def _process_response(self, response):

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -16,6 +16,10 @@ class AuthenticationBase(object):
     Args:
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/blacklists.py
+++ b/auth0/v3/management/blacklists.py
@@ -13,9 +13,9 @@ class Blacklists(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.url = 'https://{}/api/v2/blacklists/tokens'.format(domain)
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def get(self, aud=None):
         """Retrieves the jti and aud of all tokens in the blacklist.

--- a/auth0/v3/management/blacklists.py
+++ b/auth0/v3/management/blacklists.py
@@ -11,6 +11,11 @@ class Blacklists(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/client_grants.py
+++ b/auth0/v3/management/client_grants.py
@@ -12,6 +12,11 @@ class ClientGrants(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/client_grants.py
+++ b/auth0/v3/management/client_grants.py
@@ -14,9 +14,9 @@ class ClientGrants(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/client-grants'.format(self.domain)

--- a/auth0/v3/management/clients.py
+++ b/auth0/v3/management/clients.py
@@ -12,6 +12,11 @@ class Clients(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/clients.py
+++ b/auth0/v3/management/clients.py
@@ -14,9 +14,9 @@ class Clients(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/clients'.format(self.domain)

--- a/auth0/v3/management/connections.py
+++ b/auth0/v3/management/connections.py
@@ -13,9 +13,9 @@ class Connections(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/connections'.format(self.domain)

--- a/auth0/v3/management/connections.py
+++ b/auth0/v3/management/connections.py
@@ -11,6 +11,11 @@ class Connections(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/custom_domains.py
+++ b/auth0/v3/management/custom_domains.py
@@ -14,9 +14,9 @@ class CustomDomains(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://%s/api/v2/custom-domains' % self.domain

--- a/auth0/v3/management/custom_domains.py
+++ b/auth0/v3/management/custom_domains.py
@@ -12,6 +12,11 @@ class CustomDomains(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/device_credentials.py
+++ b/auth0/v3/management/device_credentials.py
@@ -14,9 +14,9 @@ class DeviceCredentials(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/device-credentials'.format(self.domain)

--- a/auth0/v3/management/device_credentials.py
+++ b/auth0/v3/management/device_credentials.py
@@ -12,6 +12,11 @@ class DeviceCredentials(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/email_templates.py
+++ b/auth0/v3/management/email_templates.py
@@ -12,6 +12,11 @@ class EmailTemplates(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/email_templates.py
+++ b/auth0/v3/management/email_templates.py
@@ -14,9 +14,9 @@ class EmailTemplates(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/email-templates'.format(self.domain)

--- a/auth0/v3/management/emails.py
+++ b/auth0/v3/management/emails.py
@@ -14,9 +14,9 @@ class Emails(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/emails/provider'.format(self.domain)

--- a/auth0/v3/management/emails.py
+++ b/auth0/v3/management/emails.py
@@ -12,6 +12,11 @@ class Emails(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/grants.py
+++ b/auth0/v3/management/grants.py
@@ -12,6 +12,11 @@ class Grants(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/grants.py
+++ b/auth0/v3/management/grants.py
@@ -14,9 +14,9 @@ class Grants(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://%s/api/v2/grants' % self.domain

--- a/auth0/v3/management/guardian.py
+++ b/auth0/v3/management/guardian.py
@@ -12,6 +12,11 @@ class Guardian(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/guardian.py
+++ b/auth0/v3/management/guardian.py
@@ -14,9 +14,9 @@ class Guardian(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/guardian'.format(self.domain)

--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -14,9 +14,9 @@ class Jobs(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, path=None):
         url = 'https://{}/api/v2/jobs'.format(self.domain)

--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -12,6 +12,11 @@ class Jobs(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/logs.py
+++ b/auth0/v3/management/logs.py
@@ -12,6 +12,11 @@ class Logs(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/logs.py
+++ b/auth0/v3/management/logs.py
@@ -14,9 +14,9 @@ class Logs(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/logs'.format(self.domain)

--- a/auth0/v3/management/resource_servers.py
+++ b/auth0/v3/management/resource_servers.py
@@ -12,6 +12,11 @@ class ResourceServers(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/resource_servers.py
+++ b/auth0/v3/management/resource_servers.py
@@ -14,9 +14,9 @@ class ResourceServers(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/resource-servers'.format(self.domain)

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -13,8 +13,9 @@ class RestClient(object):
 
     """Provides simple methods for handling all RESTful api endpoints. """
 
-    def __init__(self, jwt, telemetry=True):
+    def __init__(self, jwt, telemetry=True, timeout=5.0):
         self.jwt = jwt
+        self.timeout = timeout
 
         self.base_headers = {
             'Authorization': 'Bearer {}'.format(self.jwt),
@@ -40,38 +41,38 @@ class RestClient(object):
     def get(self, url, params=None):
         headers = self.base_headers.copy()
 
-        response = requests.get(url, params=params, headers=headers)
+        response = requests.get(url, params=params, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def post(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.post(url, json=data, headers=headers)
+        response = requests.post(url, json=data, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def file_post(self, url, data=None, files=None):
         headers = self.base_headers.copy()
         headers.pop('Content-Type', None)
 
-        response = requests.post(url, data=data, files=files, headers=headers)
+        response = requests.post(url, data=data, files=files, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def patch(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.patch(url, json=data, headers=headers)
+        response = requests.patch(url, json=data, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def put(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.put(url, json=data, headers=headers)
+        response = requests.put(url, json=data, headers=headers, timeout=self.timeout)
         return self._process_response(response)
 
     def delete(self, url, params=None, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.delete(url, headers=headers, params=params or {}, json=data)
+        response = requests.delete(url, headers=headers, params=params or {}, json=data, timeout=self.timeout)
         return self._process_response(response)
 
     def _process_response(self, response):

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -11,8 +11,16 @@ UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
 
 class RestClient(object):
 
-    """Provides simple methods for handling all RESTful api endpoints. """
+    """Provides simple methods for handling all RESTful api endpoints.
 
+    Args:
+        telemetry (bool, optional): Enable or disable Telemetry
+            (defaults to True)
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
+    """
     def __init__(self, jwt, telemetry=True, timeout=5.0):
         self.jwt = jwt
         self.timeout = timeout

--- a/auth0/v3/management/roles.py
+++ b/auth0/v3/management/roles.py
@@ -14,9 +14,9 @@ class Roles(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/roles'.format(self.domain)

--- a/auth0/v3/management/roles.py
+++ b/auth0/v3/management/roles.py
@@ -12,6 +12,11 @@ class Roles(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/rules.py
+++ b/auth0/v3/management/rules.py
@@ -14,9 +14,9 @@ class Rules(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/rules'.format(self.domain)

--- a/auth0/v3/management/rules.py
+++ b/auth0/v3/management/rules.py
@@ -12,6 +12,11 @@ class Rules(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/rules_configs.py
+++ b/auth0/v3/management/rules_configs.py
@@ -12,6 +12,11 @@ class RulesConfigs(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/rules_configs.py
+++ b/auth0/v3/management/rules_configs.py
@@ -14,9 +14,9 @@ class RulesConfigs(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://%s/api/v2/rules-configs' % self.domain

--- a/auth0/v3/management/stats.py
+++ b/auth0/v3/management/stats.py
@@ -13,9 +13,9 @@ class Stats(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, action):
         return 'https://{}/api/v2/stats/{}'.format(self.domain, action)

--- a/auth0/v3/management/stats.py
+++ b/auth0/v3/management/stats.py
@@ -11,6 +11,11 @@ class Stats(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/tenants.py
+++ b/auth0/v3/management/tenants.py
@@ -12,6 +12,11 @@ class Tenants(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/tenants.py
+++ b/auth0/v3/management/tenants.py
@@ -14,9 +14,9 @@ class Tenants(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self):
         return 'https://{}/api/v2/tenants/settings'.format(self.domain)

--- a/auth0/v3/management/tickets.py
+++ b/auth0/v3/management/tickets.py
@@ -12,6 +12,11 @@ class Tickets(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/tickets.py
+++ b/auth0/v3/management/tickets.py
@@ -14,9 +14,9 @@ class Tickets(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, action):
         return 'https://{}/api/v2/tickets/{}'.format(self.domain, action)

--- a/auth0/v3/management/user_blocks.py
+++ b/auth0/v3/management/user_blocks.py
@@ -12,6 +12,11 @@ class UserBlocks(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/user_blocks.py
+++ b/auth0/v3/management/user_blocks.py
@@ -14,9 +14,9 @@ class UserBlocks(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/user-blocks'.format(self.domain)

--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -12,6 +12,11 @@ class Users(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -14,9 +14,9 @@ class Users(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self, id=None):
         url = 'https://{}/api/v2/users'.format(self.domain)

--- a/auth0/v3/management/users_by_email.py
+++ b/auth0/v3/management/users_by_email.py
@@ -14,9 +14,9 @@ class UsersByEmail(object):
             (defaults to True)
     """
 
-    def __init__(self, domain, token, telemetry=True):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
         self.domain = domain
-        self.client = RestClient(jwt=token, telemetry=telemetry)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
 
     def _url(self):
         url = 'https://{}/api/v2/users-by-email'.format(self.domain)

--- a/auth0/v3/management/users_by_email.py
+++ b/auth0/v3/management/users_by_email.py
@@ -12,6 +12,11 @@ class UsersByEmail(object):
 
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
     """
 
     def __init__(self, domain, token, telemetry=True, timeout=5.0):

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -51,7 +51,7 @@ class TestBase(unittest.TestCase):
         data = ab.post('the-url', data={'a': 'b'}, headers={'c': 'd'})
 
         mock_post.assert_called_with(url='the-url', json={'a': 'b'},
-                headers={'c': 'd', 'Content-Type': 'application/json'})
+                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
         
@@ -66,7 +66,7 @@ class TestBase(unittest.TestCase):
         data = ab.post('the-url')
 
         mock_post.assert_called_with(url='the-url', json=None,
-                headers={'Content-Type': 'application/json'})
+                headers={'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
 
@@ -182,7 +182,7 @@ class TestBase(unittest.TestCase):
         data = ab.get('the-url', params={'a': 'b'}, headers={'c': 'd'})
 
         mock_get.assert_called_with(url='the-url', params={'a': 'b'},
-                headers={'c': 'd', 'Content-Type': 'application/json'})
+                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
 
@@ -197,7 +197,7 @@ class TestBase(unittest.TestCase):
         data = ab.get('the-url')
 
         mock_get.assert_called_with(url='the-url', params=None,
-                headers={'Content-Type': 'application/json'})
+                headers={'Content-Type': 'application/json'}, timeout=5.0)
 
         self.assertEqual(data, {'x': 'y'})
 
@@ -221,3 +221,15 @@ class TestBase(unittest.TestCase):
         self.assertIn('Auth0-Client', headers)
 
         self.assertEqual(data, {"x": "y"})
+
+    def test_get_can_timeout(self):
+        ab = AuthenticationBase('auth0.com', timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            ab.get('https://auth0.com', params={'a': 'b'}, headers={'c': 'd'})
+
+    def test_post_can_timeout(self):
+        ab = AuthenticationBase('auth0.com', timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            ab.post('https://auth0.com', data={'a': 'b'}, headers={'c': 'd'})

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -228,10 +228,10 @@ class TestBase(unittest.TestCase):
         ab = AuthenticationBase('auth0.com', timeout=0.00001)
 
         with self.assertRaises(requests.exceptions.Timeout):
-            ab.get('https://auth0.com', params={'a': 'b'}, headers={'c': 'd'})
+            ab.get('https://google.com', params={'a': 'b'}, headers={'c': 'd'})
 
     def test_post_can_timeout(self):
         ab = AuthenticationBase('auth0.com', timeout=0.00001)
 
         with self.assertRaises(requests.exceptions.Timeout):
-            ab.post('https://auth0.com', data={'a': 'b'}, headers={'c': 'd'})
+            ab.post('https://google.com', data={'a': 'b'}, headers={'c': 'd'})

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -1,5 +1,7 @@
 import base64
 import json
+from time import sleep
+
 import mock
 import sys
 import requests
@@ -43,7 +45,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.post')
     def test_post(self, mock_post):
-        ab = AuthenticationBase('auth0.com', telemetry=False)
+        ab = AuthenticationBase('auth0.com', telemetry=False, timeout=(10, 2))
 
         mock_post.return_value.status_code = 200
         mock_post.return_value.text = '{"x": "y"}'
@@ -51,7 +53,7 @@ class TestBase(unittest.TestCase):
         data = ab.post('the-url', data={'a': 'b'}, headers={'c': 'd'})
 
         mock_post.assert_called_with(url='the-url', json={'a': 'b'},
-                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=5.0)
+                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=(10, 2))
 
         self.assertEqual(data, {'x': 'y'})
         
@@ -174,7 +176,7 @@ class TestBase(unittest.TestCase):
 
     @mock.patch('requests.get')
     def test_get(self, mock_get):
-        ab = AuthenticationBase('auth0.com', telemetry=False)
+        ab = AuthenticationBase('auth0.com', telemetry=False, timeout=(10, 2))
 
         mock_get.return_value.status_code = 200
         mock_get.return_value.text = '{"x": "y"}'
@@ -182,7 +184,7 @@ class TestBase(unittest.TestCase):
         data = ab.get('the-url', params={'a': 'b'}, headers={'c': 'd'})
 
         mock_get.assert_called_with(url='the-url', params={'a': 'b'},
-                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=5.0)
+                headers={'c': 'd', 'Content-Type': 'application/json'}, timeout=(10, 2))
 
         self.assertEqual(data, {'x': 'y'})
 

--- a/auth0/v3/test/management/test_blacklists.py
+++ b/auth0/v3/test/management/test_blacklists.py
@@ -5,6 +5,12 @@ from ...management.blacklists import Blacklists
 
 class TestBlacklists(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Blacklists(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.blacklists.RestClient')
     def test_get(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_client_grants.py
+++ b/auth0/v3/test/management/test_client_grants.py
@@ -5,6 +5,12 @@ from ...management.client_grants import ClientGrants
 
 class TestClientGrants(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = ClientGrants(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.client_grants.RestClient')
     def test_all(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_clients.py
+++ b/auth0/v3/test/management/test_clients.py
@@ -5,6 +5,12 @@ from ...management.clients import Clients
 
 class TestClients(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Clients(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.clients.RestClient')
     def test_all(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_connections.py
+++ b/auth0/v3/test/management/test_connections.py
@@ -5,6 +5,12 @@ from ...management.connections import Connections
 
 class TestConnection(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Connections(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.connections.RestClient')
     def test_all(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_custom_domains.py
+++ b/auth0/v3/test/management/test_custom_domains.py
@@ -5,6 +5,12 @@ from ...management.custom_domains import CustomDomains
 
 class TestCustomDomains(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = CustomDomains(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.custom_domains.RestClient')
     def test_get_all(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_device_credentials.py
+++ b/auth0/v3/test/management/test_device_credentials.py
@@ -5,6 +5,12 @@ from ...management.device_credentials import DeviceCredentials
 
 class TestDeviceCredentials(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = DeviceCredentials(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.device_credentials.RestClient')
     def test_get(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_email_endpoints.py
+++ b/auth0/v3/test/management/test_email_endpoints.py
@@ -5,6 +5,12 @@ from ...management.email_templates import EmailTemplates
 
 class TestClients(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = EmailTemplates(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.email_templates.RestClient')
     def test_create(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_emails.py
+++ b/auth0/v3/test/management/test_emails.py
@@ -5,6 +5,12 @@ from ...management.emails import Emails
 
 class TestEmails(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Emails(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.emails.RestClient')
     def test_get(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_grants.py
+++ b/auth0/v3/test/management/test_grants.py
@@ -5,6 +5,12 @@ from ...management.grants import Grants
 
 class TestGrants(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Grants(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.grants.RestClient')
     def test_get_all(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_guardian.py
+++ b/auth0/v3/test/management/test_guardian.py
@@ -5,6 +5,12 @@ from ...management.guardian import Guardian
 
 class TestGuardian(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Guardian(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.guardian.RestClient')
     def test_all_factors(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_jobs.py
+++ b/auth0/v3/test/management/test_jobs.py
@@ -5,6 +5,12 @@ from ...management.jobs import Jobs
 
 class TestJobs(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Jobs(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.jobs.RestClient')
     def test_get(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_logs.py
+++ b/auth0/v3/test/management/test_logs.py
@@ -5,6 +5,12 @@ from ...management.logs import Logs
 
 class TestLogs(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Logs(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.logs.RestClient')
     def test_search(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_resource_servers.py
+++ b/auth0/v3/test/management/test_resource_servers.py
@@ -5,6 +5,12 @@ from ...management.resource_servers import ResourceServers
 
 class TestResourceServers(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = ResourceServers(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.resource_servers.RestClient')
     def test_create(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -16,31 +16,31 @@ class TestRest(unittest.TestCase):
         rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
 
         with self.assertRaises(requests.exceptions.Timeout):
-            rc.get('http://auth0.com')
+            rc.get('http://google.com')
 
     def test_post_can_timeout(self):
         rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
 
         with self.assertRaises(requests.exceptions.Timeout):
-            rc.post('http://auth0.com')
+            rc.post('http://google.com')
 
     def test_put_can_timeout(self):
         rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
 
         with self.assertRaises(requests.exceptions.Timeout):
-            rc.put('http://auth0.com')
+            rc.put('http://google.com')
 
     def test_patch_can_timeout(self):
         rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
 
         with self.assertRaises(requests.exceptions.Timeout):
-            rc.patch('http://auth0.com')
+            rc.patch('http://google.com')
 
     def test_delete_can_timeout(self):
         rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
 
         with self.assertRaises(requests.exceptions.Timeout):
-            rc.delete('http://auth0.com')
+            rc.delete('http://google.com')
 
     @mock.patch('requests.get')
     def test_get_custom_timeout(self, mock_get):

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -22,14 +22,14 @@ class TestRest(unittest.TestCase):
         mock_get.return_value.status_code = 200
 
         response = rc.get('the-url')
-        mock_get.assert_called_with('the-url', params=None, headers=headers)
+        mock_get.assert_called_with('the-url', params=None, headers=headers, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
         response = rc.get(url='the/url', params={'A': 'param', 'B': 'param'})
         mock_get.assert_called_with('the/url', params={'A': 'param',
                                                        'B': 'param'},
-                                    headers=headers)
+                                    headers=headers, timeout=5.0)
         self.assertEqual(response, ['a', 'b'])
 
         mock_get.return_value.text = ''
@@ -65,7 +65,7 @@ class TestRest(unittest.TestCase):
         mock_post.return_value.status_code = 200
         response = rc.post('the/url', data=data)
         mock_post.assert_called_with('the/url', json=data,
-                                     headers=headers)
+                                     headers=headers, timeout=5.0)
 
         self.assertEqual(response, {'a': 'b'})
 
@@ -213,7 +213,7 @@ class TestRest(unittest.TestCase):
 
         rc.file_post('the-url', data=data, files=files)
 
-        mock_post.assert_called_once_with('the-url', data=data, files=files, headers=headers)
+        mock_post.assert_called_once_with('the-url', data=data, files=files, headers=headers, timeout=5.0)
 
 
     @mock.patch('requests.put')
@@ -229,7 +229,7 @@ class TestRest(unittest.TestCase):
 
         response = rc.put(url='the-url', data=data)
         mock_put.assert_called_with('the-url', json=data,
-                                      headers=headers)
+                                      headers=headers, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
@@ -262,7 +262,7 @@ class TestRest(unittest.TestCase):
 
         response = rc.patch(url='the-url', data=data)
         mock_patch.assert_called_with('the-url', json=data,
-                                      headers=headers)
+                                      headers=headers, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
@@ -294,7 +294,7 @@ class TestRest(unittest.TestCase):
         mock_delete.return_value.status_code = 200
 
         response = rc.delete(url='the-url/ID')
-        mock_delete.assert_called_with('the-url/ID', headers=headers, params={}, json=None)
+        mock_delete.assert_called_with('the-url/ID', headers=headers, params={}, json=None, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 
@@ -313,7 +313,7 @@ class TestRest(unittest.TestCase):
         params={'A': 'param', 'B': 'param'}
 
         response = rc.delete(url='the-url/ID', params=params, data=data)
-        mock_delete.assert_called_with('the-url/ID', headers=headers, params=params, json=data)
+        mock_delete.assert_called_with('the-url/ID', headers=headers, params=params, json=data, timeout=5.0)
 
         self.assertEqual(response, ['a', 'b'])
 

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -2,13 +2,110 @@ import unittest
 import sys
 import json
 import base64
-import requests
+
 import mock
+import requests
+
 from ...management.rest import RestClient
 from ...exceptions import Auth0Error
 
 
 class TestRest(unittest.TestCase):
+
+    def test_get_can_timeout(self):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            rc.get('http://auth0.com')
+
+    def test_post_can_timeout(self):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            rc.post('http://auth0.com')
+
+    def test_put_can_timeout(self):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            rc.put('http://auth0.com')
+
+    def test_patch_can_timeout(self):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            rc.patch('http://auth0.com')
+
+    def test_delete_can_timeout(self):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=0.00001)
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            rc.delete('http://auth0.com')
+
+    @mock.patch('requests.get')
+    def test_get_custom_timeout(self, mock_get):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=(10, 2))
+        headers = {
+            'Authorization': 'Bearer a-token',
+            'Content-Type': 'application/json',
+        }
+        mock_get.return_value.text = '["a", "b"]'
+        mock_get.return_value.status_code = 200
+
+        rc.get('the-url')
+        mock_get.assert_called_with('the-url', params=None, headers=headers, timeout=(10, 2))
+
+    @mock.patch('requests.post')
+    def test_post_custom_timeout(self, mock_post):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=(10, 2))
+        headers = {
+            'Authorization': 'Bearer a-token',
+            'Content-Type': 'application/json',
+        }
+        mock_post.return_value.text = '["a", "b"]'
+        mock_post.return_value.status_code = 200
+
+        rc.post('the-url')
+        mock_post.assert_called_with('the-url', json=None, headers=headers, timeout=(10, 2))
+
+    @mock.patch('requests.put')
+    def test_put_custom_timeout(self, mock_put):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=(10, 2))
+        headers = {
+            'Authorization': 'Bearer a-token',
+            'Content-Type': 'application/json',
+        }
+        mock_put.return_value.text = '["a", "b"]'
+        mock_put.return_value.status_code = 200
+
+        rc.put('the-url')
+        mock_put.assert_called_with('the-url', json=None, headers=headers, timeout=(10, 2))
+
+    @mock.patch('requests.patch')
+    def test_patch_custom_timeout(self, mock_patch):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=(10, 2))
+        headers = {
+            'Authorization': 'Bearer a-token',
+            'Content-Type': 'application/json',
+        }
+        mock_patch.return_value.text = '["a", "b"]'
+        mock_patch.return_value.status_code = 200
+
+        rc.patch('the-url')
+        mock_patch.assert_called_with('the-url', json=None, headers=headers, timeout=(10, 2))
+
+    @mock.patch('requests.delete')
+    def test_delete_custom_timeout(self, mock_delete):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=(10, 2))
+        headers = {
+            'Authorization': 'Bearer a-token',
+            'Content-Type': 'application/json',
+        }
+        mock_delete.return_value.text = '["a", "b"]'
+        mock_delete.return_value.status_code = 200
+
+        rc.delete('the-url')
+        mock_delete.assert_called_with('the-url', params={}, json=None, headers=headers, timeout=(10, 2))
 
     @mock.patch('requests.get')
     def test_get(self, mock_get):

--- a/auth0/v3/test/management/test_roles.py
+++ b/auth0/v3/test/management/test_roles.py
@@ -5,6 +5,12 @@ from ...management.roles import Roles
 
 class TestRoles(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Roles(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.roles.RestClient')
     def test_list(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_rules.py
+++ b/auth0/v3/test/management/test_rules.py
@@ -5,6 +5,12 @@ from ...management.rules import Rules
 
 class TestRules(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Rules(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.rules.RestClient')
     def test_all(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_rules_configs.py
+++ b/auth0/v3/test/management/test_rules_configs.py
@@ -3,7 +3,13 @@ import mock
 from ...management.rules_configs import RulesConfigs
 
 
-class TestRules(unittest.TestCase):
+class TestRulesConfigs(unittest.TestCase):
+
+    def test_init_with_optionals(self):
+        t = RulesConfigs(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
 
     @mock.patch('auth0.v3.management.rules_configs.RestClient')
     def test_all(self, mock_rc):

--- a/auth0/v3/test/management/test_stats.py
+++ b/auth0/v3/test/management/test_stats.py
@@ -3,7 +3,13 @@ import mock
 from ...management.stats import Stats
 
 
-class TestTickets(unittest.TestCase):
+class TestStats(unittest.TestCase):
+
+    def test_init_with_optionals(self):
+        t = Stats(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
 
     @mock.patch('auth0.v3.management.stats.RestClient')
     def test_active_users(self, mock_rc):

--- a/auth0/v3/test/management/test_tenants.py
+++ b/auth0/v3/test/management/test_tenants.py
@@ -5,6 +5,12 @@ from ...management.tenants import Tenants
 
 class TestTenants(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Tenants(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.tenants.RestClient')
     def test_get(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_tickets.py
+++ b/auth0/v3/test/management/test_tickets.py
@@ -5,6 +5,12 @@ from ...management.tickets import Tickets
 
 class TestTickets(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Tickets(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.tickets.RestClient')
     def test_email(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_user_blocks.py
+++ b/auth0/v3/test/management/test_user_blocks.py
@@ -5,6 +5,12 @@ from ...management.user_blocks import UserBlocks
 
 class TestUserBlocks(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = UserBlocks(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.user_blocks.RestClient')
     def test_get_by_identifier(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_users.py
+++ b/auth0/v3/test/management/test_users.py
@@ -5,6 +5,12 @@ from ...management.users import Users
 
 class TestUsers(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = Users(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.users.RestClient')
     def test_list(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_users_by_email.py
+++ b/auth0/v3/test/management/test_users_by_email.py
@@ -5,6 +5,12 @@ from ...management.users_by_email import UsersByEmail
 
 class TestUsersByEmail(unittest.TestCase):
 
+    def test_init_with_optionals(self):
+        t = UsersByEmail(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
     @mock.patch('auth0.v3.management.users_by_email.RestClient')
     def test_search_users_by_email(self, mock_rc):
         mock_instance = mock_rc.return_value


### PR DESCRIPTION
### Changes

The connect and read timeout can be customized in the `requests` dependency whenever an HTTP method is called. This is a per request setting, not global.

The accepted values are either a `float` to setting both timeout values to the same value, or a `tuple` to decide values separately.

#### Open to suggestions
- [ ] The default timeout value for both attributes on this PR is set to 5 seconds. Should that change?

### References

This PR is built on top of #209 (see first commit) and supersedes it.

Docs on the attribute: http://requests.kennethreitz.org/en/master/user/advanced/#id16

### Testing

Followed the idea on this comment https://github.com/auth0/auth0-python/pull/209#issuecomment-538047260

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
