### PR TITLE
Add deprecation note for DELETE /users (all users)

### DIFF
--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -1,4 +1,5 @@
 from .rest import RestClient
+import warnings
 
 
 class Users(object):
@@ -87,9 +88,11 @@ class Users(object):
 
     def delete_all_users(self):
         """Deletes all users (USE WITH CAUTION).
+        Deprecation: This endpoint is no longer available server-side.
 
         Args:
         """
+        warnings.warn("DELETE all users endpoint is no longer available.", DeprecationWarning)
         return self.client.delete(self._url())
 
     def get(self, id, fields=None, include_fields=True):


### PR DESCRIPTION
### Changes

This method was added 5 years ago. It seems it is no longer available nor documented on the API2 docs. This PR prints a warning to whoever is still calling it. 

The use of the method would result on a 404 response from the server.

### References
https://auth0.com/docs/api/management/v2#!/Users

