### PR TITLE
Expose the time at which the Rate Limit will reset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ When consuming methods from the API clients, the requests could fail for a numbe
 - Invalid data sent as part of the request: An ``Auth0Error` is raised with the error code and description.
 - Global or Client Rate Limit reached: A ``RateLimitError`` is raised and the time at which the limit
 resets is exposed in the ``reset_at`` property. When the header is unset, this value will be ``-1``.
-- Network timeouts: Adjustable by passing a the ``timeout`` argument to the client. See the `rate limit docs <https://auth0.com/docs/policies/rate-limits>`_ for details.
+- Network timeouts: Adjustable by passing a ``timeout`` argument to the client. See the `rate limit docs <https://auth0.com/docs/policies/rate-limits>`_ for details.
 
 Available Management Endpoints
 ==============================

--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,16 @@ With all in place, the next snippets shows how to verify an RS256 signed ID toke
 Provided something goes wrong, a ``TokenValidationError`` will be raised. In this
 scenario, the ID token should be deemed invalid and its contents not be trusted.
 
+==============
+Error Handling
+==============
+
+When consuming methods from the API clients, the requests could fail for a number of reasons:
+- Invalid data sent as part of the request: An ``Auth0Error` is raised with the error code and description.
+- Global or Client Rate Limit reached: A ``RateLimitError`` is raised and the time at which the limit
+resets is exposed in the ``reset_at`` property. When the header is unset, this value will be ``-1``.
+- Network timeouts: Adjustable by passing a the ``timeout`` argument to the client. See the `rate limit docs <https://auth0.com/docs/policies/rate-limits>`_ for details.
+
 Available Management Endpoints
 ==============================
 

--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -3,14 +3,12 @@ import json
 import sys
 import platform
 import requests
-from ..exceptions import Auth0Error
-
+from ..exceptions import Auth0Error, RateLimitError
 
 UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
 
 
 class AuthenticationBase(object):
-
     """Base authentication object providing simple REST methods.
 
     Args:
@@ -69,12 +67,19 @@ class AuthenticationBase(object):
 
 
 class Response(object):
-    def __init__(self, status_code, content):
+    def __init__(self, status_code, content, headers):
         self._status_code = status_code
         self._content = content
+        self._headers = headers
 
     def content(self):
         if self._is_error():
+            if self._status_code == 429:
+                reset_at = int(self._headers.get('x-ratelimit-reset', '-1'))
+                raise RateLimitError(error_code=self._error_code(),
+                                     message=self._error_message(),
+                                     reset_at=reset_at)
+
             raise Auth0Error(status_code=self._status_code,
                              error_code=self._error_code(),
                              message=self._error_message())
@@ -95,7 +100,7 @@ class Response(object):
 class JsonResponse(Response):
     def __init__(self, response):
         content = json.loads(response.text)
-        super(JsonResponse, self).__init__(response.status_code, content)
+        super(JsonResponse, self).__init__(response.status_code, content, response.headers)
 
     def _error_code(self):
         if 'error' in self._content:
@@ -111,7 +116,7 @@ class JsonResponse(Response):
 
 class PlainResponse(Response):
     def __init__(self, response):
-        super(PlainResponse, self).__init__(response.status_code, response.text)
+        super(PlainResponse, self).__init__(response.status_code, response.text, response.headers)
 
     def _error_code(self):
         return UNKNOWN_ERROR
@@ -122,7 +127,7 @@ class PlainResponse(Response):
 
 class EmptyResponse(Response):
     def __init__(self, status_code):
-        super(EmptyResponse, self).__init__(status_code, '')
+        super(EmptyResponse, self).__init__(status_code, '', {})
 
     def _error_code(self):
         return UNKNOWN_ERROR

--- a/auth0/v3/exceptions.py
+++ b/auth0/v3/exceptions.py
@@ -8,5 +8,11 @@ class Auth0Error(Exception):
         return '{}: {}'.format(self.status_code, self.message)
 
 
+class RateLimitError(Auth0Error):
+    def __init__(self, error_code, message, reset_at):
+        super(RateLimitError, self).__init__(status_code=429, error_code=error_code, message=message)
+        self.reset_at = reset_at
+
+
 class TokenValidationError(Exception):
     pass


### PR DESCRIPTION
### Changes

When too many requests have been made against the server, the next request will fail with a `429`. In the response headers there will be extra information, such as the time at which this limit is reset.

With this PR: 
* `429` errors are raised as `RateLimitError` instead of `Auth0Error`. 
* They will expose a property `reset_at` with the value of the `X-RateLimit-Reset` header. This value represents the Unix timestamp at which the limit will be reset.
* When this header is not set, a value of -1 will be set as default.

### References

More info https://auth0.com/docs/policies/rate-limits

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
