### PR TITLE
Add send_completion_email to users import job

### DIFF
--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -72,7 +72,7 @@ class Jobs(object):
         """
         return self.client.post(self._url('users-exports'), data=body)
 
-    def import_users(self, connection_id, file_obj, upsert=False):
+    def import_users(self, connection_id, file_obj, upsert=False, send_completion_email=True):
         """Imports users to a connection from a file.
 
         Args:
@@ -82,10 +82,21 @@ class Jobs(object):
             file_obj (file): A file-like object to upload. The format for
                 this file is explained in: https://auth0.com/docs/bulk-import
 
+            upsert (bool): When set to False, pre-existing users that match on email address, user ID, or username
+                will fail. When set to True, pre-existing users that match on any of these fields will be updated, but
+                only with upsertable attributes. Defaults to False.
+                For a list of user profile fields that can be upserted during import, see the following article
+                https://auth0.com/docs/users/references/user-profile-structure#user-profile-attributes
+
+            send_completion_email (bool): When set to True, an email will be sent to notify the completion of this job.
+                When set to False, no email will be sent. Defaults to True.
+
         See: https://auth0.com/docs/api/management/v2#!/Jobs/post_users_imports
         """
         return self.client.file_post(self._url('users-imports'),
-                                     data={'connection_id': connection_id, 'upsert': str(upsert).lower()},
+                                     data={'connection_id': connection_id,
+                                           'upsert': str(upsert).lower(),
+                                           'send_completion_email': str(send_completion_email).lower()},
                                      files={'users': file_obj})
 
     def send_verification_email(self, body):

--- a/auth0/v3/test/management/test_jobs.py
+++ b/auth0/v3/test/management/test_jobs.py
@@ -65,21 +65,21 @@ class TestJobs(unittest.TestCase):
 
         mock_instance.file_post.assert_called_with(
             'https://domain/api/v2/jobs/users-imports',
-            data={'connection_id': '1234', 'upsert': 'false'},
+            data={'connection_id': '1234', 'upsert': 'false', 'send_completion_email': 'true'},
             files={'users': {}}
         )
 
-        j.import_users(connection_id='1234', file_obj={}, upsert=True)
+        j.import_users(connection_id='1234', file_obj={}, upsert=True, send_completion_email=False)
         mock_instance.file_post.assert_called_with(
             'https://domain/api/v2/jobs/users-imports',
-            data={'connection_id': '1234', 'upsert': 'true'},
+            data={'connection_id': '1234', 'upsert': 'true', 'send_completion_email': 'false'},
             files={'users': {}}
         )
 
-        j.import_users(connection_id='1234', file_obj={}, upsert=False)
+        j.import_users(connection_id='1234', file_obj={}, upsert=False, send_completion_email=True)
         mock_instance.file_post.assert_called_with(
             'https://domain/api/v2/jobs/users-imports',
-            data={'connection_id': '1234', 'upsert': 'false'},
+            data={'connection_id': '1234', 'upsert': 'false', 'send_completion_email': 'true'},
             files={'users': {}}
         )
 


### PR DESCRIPTION
### Changes

Add missing parameter when creating a users import job.

### References

Resolves https://github.com/auth0/auth0-python/issues/210

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
