### PR TITLE
Add missing external_id property to the import users job

### DIFF
--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -2,7 +2,6 @@ from .rest import RestClient
 
 
 class Jobs(object):
-
     """Auth0 jobs endpoints
 
     Args:
@@ -72,7 +71,7 @@ class Jobs(object):
         """
         return self.client.post(self._url('users-exports'), data=body)
 
-    def import_users(self, connection_id, file_obj, upsert=False, send_completion_email=True):
+    def import_users(self, connection_id, file_obj, upsert=False, send_completion_email=True, external_id=None):
         """Imports users to a connection from a file.
 
         Args:
@@ -91,12 +90,15 @@ class Jobs(object):
             send_completion_email (bool): When set to True, an email will be sent to notify the completion of this job.
                 When set to False, no email will be sent. Defaults to True.
 
+            external_id (str):  Customer-defined ID.
+
         See: https://auth0.com/docs/api/management/v2#!/Jobs/post_users_imports
         """
         return self.client.file_post(self._url('users-imports'),
                                      data={'connection_id': connection_id,
                                            'upsert': str(upsert).lower(),
-                                           'send_completion_email': str(send_completion_email).lower()},
+                                           'send_completion_email': str(send_completion_email).lower(),
+                                           'external_id': external_id},
                                      files={'users': file_obj})
 
     def send_verification_email(self, body):

--- a/auth0/v3/test/management/test_jobs.py
+++ b/auth0/v3/test/management/test_jobs.py
@@ -65,21 +65,21 @@ class TestJobs(unittest.TestCase):
 
         mock_instance.file_post.assert_called_with(
             'https://domain/api/v2/jobs/users-imports',
-            data={'connection_id': '1234', 'upsert': 'false', 'send_completion_email': 'true'},
+            data={'connection_id': '1234', 'upsert': 'false', 'send_completion_email': 'true', 'external_id': None},
             files={'users': {}}
         )
 
-        j.import_users(connection_id='1234', file_obj={}, upsert=True, send_completion_email=False)
+        j.import_users(connection_id='1234', file_obj={}, upsert=True, send_completion_email=False, external_id="ext-id-123")
         mock_instance.file_post.assert_called_with(
             'https://domain/api/v2/jobs/users-imports',
-            data={'connection_id': '1234', 'upsert': 'true', 'send_completion_email': 'false'},
+            data={'connection_id': '1234', 'upsert': 'true', 'send_completion_email': 'false', 'external_id': 'ext-id-123'},
             files={'users': {}}
         )
 
         j.import_users(connection_id='1234', file_obj={}, upsert=False, send_completion_email=True)
         mock_instance.file_post.assert_called_with(
             'https://domain/api/v2/jobs/users-imports',
-            data={'connection_id': '1234', 'upsert': 'false', 'send_completion_email': 'true'},
+            data={'connection_id': '1234', 'upsert': 'false', 'send_completion_email': 'true', 'external_id': None},
             files={'users': {}}
         )
 


### PR DESCRIPTION
### Changes

The endpoint was missing the `external_id` property.

### References

Resolves `SDK-1625`

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
