### PR TITLE
Add Hooks management API

### DIFF
--- a/auth0/v3/management/auth0.py
+++ b/auth0/v3/management/auth0.py
@@ -8,6 +8,7 @@ from .device_credentials import DeviceCredentials
 from .emails import Emails
 from .email_templates import EmailTemplates
 from .guardian import Guardian
+from .hooks import Hooks
 from .jobs import Jobs
 from .logs import Logs
 from .resource_servers import ResourceServers
@@ -42,6 +43,7 @@ class Auth0(object):
         self.email_templates = EmailTemplates(domain, token)
         self.grants = Grants(domain, token)
         self.guardian = Guardian(domain, token)
+        self.hooks = Hooks(domain, token)
         self.jobs = Jobs(domain, token)
         self.logs = Logs(domain, token)
         self.resource_servers = ResourceServers(domain, token)

--- a/auth0/v3/management/hooks.py
+++ b/auth0/v3/management/hooks.py
@@ -1,0 +1,188 @@
+from auth0.v3.management.rest import RestClient
+
+
+class Hooks(object):
+
+    """Hooks endpoint implementation.
+
+    Args:
+        domain (str): Your Auth0 domain, e.g: 'username.auth0.com'
+
+        token (str): Management API v2 Token
+
+        telemetry (bool, optional): Enable or disable Telemetry
+            (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
+    """
+
+    def __init__(self, domain, token, telemetry=True, timeout=5.0):
+        self.domain = domain
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+
+    def _url(self, id=None):
+        url = "https://{}/api/v2/hooks".format(self.domain)
+        if id is not None:
+            return "{}/{}".format(url, id)
+        return url
+
+    def all(
+        self,
+        enabled=True,
+        fields=None,
+        include_fields=True,
+        page=None,
+        per_page=None,
+        include_totals=False,
+    ):
+        """Retrieves a list of all hooks.
+
+        Args:
+            enabled (bool, optional): If provided, retrieves hooks that match
+                the value, otherwise all hooks are retrieved.
+
+            fields (list, optional): A list of fields to include or exclude
+                (depending on include_fields) from the result, empty to
+                retrieve all fields.
+
+            include_fields (bool, optional): True if the fields specified are
+                to be included in the result, False otherwise
+                (defaults to true).
+
+            page (int, optional): The result's page number (zero based).
+
+            per_page (int, optional): The amount of entries per page.
+
+            include_totals (bool, optional): True if the query summary is
+                to be included in the result, False otherwise.
+
+        See: https://auth0.com/docs/api/management/v2#!/Hooks/get_hooks
+        """
+
+        params = {
+            "fields": fields and ",".join(fields) or None,
+            "include_fields": str(include_fields).lower(),
+            "page": page,
+            "per_page": per_page,
+            "include_totals": str(include_totals).lower(),
+        }
+
+        # since the default is True, this is here to disable the filter
+        if enabled is not None:
+            params["enabled"] = str(enabled).lower()
+
+        return self.client.get(self._url(), params=params)
+
+    def create(self, body):
+        """Creates a new Hook.
+
+        Args:
+            body (dict): Attributes for the newly created hook,
+                See: https://auth0.com/docs/api/v2#!/Hooks/post_hooks
+        """
+        return self.client.post(self._url(), data=body)
+
+    def get(self, id, fields=None, include_fields=True):
+        """Retrieves a hook by its ID.
+
+        Args:
+            id (str): The id of the hook to retrieve.
+
+            fields (list, optional): A list of fields to include or exclude
+                (depending on include_fields) from the result, empty to
+                retrieve all fields.
+
+            include_fields (bool, optional): True if the fields specified are
+                to be included in the result, False otherwise
+                (defaults to true).
+
+        See: https://auth0.com/docs/api/management/v2#!/Hooks/get_hooks_by_id
+        """
+        params = {
+            "fields": fields and ",".join(fields) or None,
+            "include_fields": str(include_fields).lower(),
+        }
+        return self.client.get(self._url(id), params=params)
+
+    def delete(self, id):
+        """Deletes a hook.
+
+        Args:
+            id (str): The id of the hook to delete.
+
+        See: https://auth0.com/docs/api/management/v2#!/Hooks/delete_hooks_by_id
+        """
+        return self.client.delete(self._url(id))
+
+    def update(self, id, body):
+        """Updates an existing hook.
+
+        Args:
+            id (str): The id of the hook to modify.
+
+            body (dict): Attributes to modify.
+
+        See: https://auth0.com/docs/api/v2#!/Hooks/patch_hooks_by_id
+        """
+        return self.client.patch(self._url(id), data=body)
+
+    def get_secrets(self, id, fields=None, include_fields=True):
+        """Retrieves a hook's secrets.
+
+        Args:
+            id (str): The id of the hook to retrieve secrets from.
+
+            fields (list, optional): A list of fields to include or exclude
+                (depending on include_fields) from the result, empty to
+                retrieve all fields.
+
+            include_fields (bool, optional): True if the fields specified are
+                to be included in the result, False otherwise
+                (defaults to true).
+
+        See: https://auth0.com/docs/api/management/v2#!/Hooks/get_secrets
+        """
+        params = {
+            "fields": fields and ",".join(fields) or None,
+            "include_fields": str(include_fields).lower(),
+        }
+        return self.client.get(self._url("%s/secrets" % id), params=params)
+
+    def add_secrets(self, id, body):
+        """Add one or more secrets for an existing hook.
+
+        Args:
+            id (str): The id of the hook to add secrets to.
+
+            body (dict): Dict of key-value pairs where the value must be a string.
+
+        See: https://auth0.com/docs/api/management/v2#!/Hooks/post_secrets
+        """
+        return self.client.post(self._url("%s/secrets" % id), data=body)
+
+    def delete_secrets(self, id, body):
+        """Delete one or more existing secrets for an existing hook.
+
+        Args:
+            id (str): The id of the hook to add secrets to.
+
+            body (list): List of secret names to delete.
+
+        See: https://auth0.com/docs/api/management/v2#!/Hooks/delete_secrets
+        """
+        return self.client.delete(self._url("%s/secrets" % id), data=body)
+
+    def update_secrets(self, id, body):
+        """Update one or more existing secrets for an existing hook.
+
+        Args:
+            id (str): The id of the hook to add secrets to.
+
+            body (dict): Dict of key-value pairs where the value must be a string.
+
+        See: https://auth0.com/docs/api/management/v2#!/Hooks/patch_secrets
+        """
+        return self.client.patch(self._url("%s/secrets" % id), data=body)

--- a/auth0/v3/management/hooks.py
+++ b/auth0/v3/management/hooks.py
@@ -85,7 +85,7 @@ class Hooks(object):
         """
         return self.client.post(self._url(), data=body)
 
-    def get(self, id, fields=None, include_fields=True):
+    def get(self, id, fields=None):
         """Retrieves a hook by its ID.
 
         Args:
@@ -95,15 +95,10 @@ class Hooks(object):
                 (depending on include_fields) from the result, empty to
                 retrieve all fields.
 
-            include_fields (bool, optional): True if the fields specified are
-                to be included in the result, False otherwise
-                (defaults to true).
-
         See: https://auth0.com/docs/api/management/v2#!/Hooks/get_hooks_by_id
         """
         params = {
             "fields": fields and ",".join(fields) or None,
-            "include_fields": str(include_fields).lower(),
         }
         return self.client.get(self._url(id), params=params)
 

--- a/auth0/v3/management/hooks.py
+++ b/auth0/v3/management/hooks.py
@@ -129,27 +129,16 @@ class Hooks(object):
         """
         return self.client.patch(self._url(id), data=body)
 
-    def get_secrets(self, id, fields=None, include_fields=True):
+    def get_secrets(self, id):
         """Retrieves a hook's secrets.
 
         Args:
             id (str): The id of the hook to retrieve secrets from.
 
-            fields (list, optional): A list of fields to include or exclude
-                (depending on include_fields) from the result, empty to
-                retrieve all fields.
-
-            include_fields (bool, optional): True if the fields specified are
-                to be included in the result, False otherwise
-                (defaults to true).
-
         See: https://auth0.com/docs/api/management/v2#!/Hooks/get_secrets
         """
-        params = {
-            "fields": fields and ",".join(fields) or None,
-            "include_fields": str(include_fields).lower(),
-        }
-        return self.client.get(self._url("%s/secrets" % id), params=params)
+
+        return self.client.get(self._url("%s/secrets" % id))
 
     def add_secrets(self, id, body):
         """Add one or more secrets for an existing hook.

--- a/auth0/v3/management/hooks.py
+++ b/auth0/v3/management/hooks.py
@@ -1,4 +1,4 @@
-from auth0.v3.management.rest import RestClient
+from .rest import RestClient
 
 
 class Hooks(object):

--- a/auth0/v3/test/management/test_auth0.py
+++ b/auth0/v3/test/management/test_auth0.py
@@ -10,6 +10,7 @@ from ...management.emails import Emails
 from ...management.email_templates import EmailTemplates
 from ...management.grants import Grants
 from ...management.guardian import Guardian
+from ...management.hooks import Hooks
 from ...management.jobs import Jobs
 from ...management.logs import Logs
 from ...management.resource_servers import ResourceServers
@@ -60,6 +61,9 @@ class TestAuth0(unittest.TestCase):
 
     def test_guardian(self):
         self.assertIsInstance(self.a0.guardian, Guardian)
+
+    def test_hooks(self):
+        self.assertIsInstance(self.a0.hooks, Hooks)
 
     def test_jobs(self):
         self.assertIsInstance(self.a0.jobs, Jobs)

--- a/auth0/v3/test/management/test_hooks.py
+++ b/auth0/v3/test/management/test_hooks.py
@@ -138,16 +138,7 @@ class TestRules(unittest.TestCase):
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/hooks/an-id/secrets', args[0])
-        self.assertEqual(kwargs['params'], {'fields': None,
-                                            'include_fields': 'true'})
-
-        c.get_secrets('an-id', fields=['a', 'b'], include_fields=False)
-
-        args, kwargs = mock_instance.get.call_args
-
-        self.assertEqual('https://domain/api/v2/hooks/an-id/secrets', args[0])
-        self.assertEqual(kwargs['params'], {'fields': 'a,b',
-                                            'include_fields': 'false'})
+        self.assertNotIn("params", kwargs)
 
     @mock.patch('auth0.v3.management.hooks.RestClient')
     def test_delete_secrets(self, mock_rc):

--- a/auth0/v3/test/management/test_hooks.py
+++ b/auth0/v3/test/management/test_hooks.py
@@ -81,16 +81,14 @@ class TestRules(unittest.TestCase):
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/hooks/an-id', args[0])
-        self.assertEqual(kwargs['params'], {'fields': None,
-                                            'include_fields': 'true'})
+        self.assertEqual(kwargs['params'], {'fields': None})
 
-        c.get('an-id', fields=['a', 'b'], include_fields=False)
+        c.get('an-id', fields=['a', 'b'])
 
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/hooks/an-id', args[0])
-        self.assertEqual(kwargs['params'], {'fields': 'a,b',
-                                            'include_fields': 'false'})
+        self.assertEqual(kwargs['params'], {'fields': 'a,b'})
 
     @mock.patch('auth0.v3.management.hooks.RestClient')
     def test_delete(self, mock_rc):

--- a/auth0/v3/test/management/test_hooks.py
+++ b/auth0/v3/test/management/test_hooks.py
@@ -1,0 +1,174 @@
+import unittest
+import mock
+from ...management.hooks import Hooks
+
+
+class TestRules(unittest.TestCase):
+
+    def test_init_with_optionals(self):
+        t = Hooks(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
+        self.assertEqual(t.client.timeout, (10, 2))
+        telemetry_header = t.client.base_headers.get('Auth0-Client', None)
+        self.assertEqual(telemetry_header, None)
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_all(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+
+        # with default params
+        c.all()
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks', args[0])
+        self.assertEqual(kwargs['params'], {
+            "enabled": 'true',
+            "fields": None,
+            "include_fields": 'true',
+            "page": None,
+            "per_page": None,
+            "include_totals": 'false',
+        })
+
+        # with fields params
+        c.all(enabled=False, fields=['a', 'b'],
+              include_fields=False)
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks', args[0])
+        self.assertEqual(kwargs['params'], {'fields': 'a,b',
+                                            'include_fields': 'false',
+                                            'enabled': 'false',
+                                            'page': None,
+                                            'per_page': None,
+                                            'include_totals': 'false'})
+
+        # with pagination params
+        c.all(page=3, per_page=27, include_totals=True)
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks', args[0])
+        self.assertEqual(kwargs['params'], {'fields': None,
+                                            'include_fields': 'true',
+                                            'enabled': 'true',
+                                            'page': 3,
+                                            'per_page': 27,
+                                            'include_totals': 'true'})
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_create(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.create({'a': 'b', 'c': 'd'})
+
+        args, kwargs = mock_instance.post.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks', args[0])
+        self.assertEqual(kwargs['data'], {'a': 'b', 'c': 'd'})
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_get(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.get('an-id')
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id', args[0])
+        self.assertEqual(kwargs['params'], {'fields': None,
+                                            'include_fields': 'true'})
+
+        c.get('an-id', fields=['a', 'b'], include_fields=False)
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id', args[0])
+        self.assertEqual(kwargs['params'], {'fields': 'a,b',
+                                            'include_fields': 'false'})
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_delete(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.delete('an-id')
+
+        mock_instance.delete.assert_called_with(
+            'https://domain/api/v2/hooks/an-id'
+        )
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_update(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.update('an-id', {'a': 'b', 'c': 'd'})
+
+        args, kwargs = mock_instance.patch.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id', args[0])
+        self.assertEqual(kwargs['data'], {'a': 'b', 'c': 'd'})
+
+    # test for hooks secrets
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_add_secret(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.add_secrets('an-id', {'a': 'b', 'c': 'd'})
+
+        args, kwargs = mock_instance.post.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id/secrets', args[0])
+        self.assertEqual(kwargs['data'], {'a': 'b', 'c': 'd'})
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_get_secrets(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.get_secrets('an-id')
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id/secrets', args[0])
+        self.assertEqual(kwargs['params'], {'fields': None,
+                                            'include_fields': 'true'})
+
+        c.get_secrets('an-id', fields=['a', 'b'], include_fields=False)
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id/secrets', args[0])
+        self.assertEqual(kwargs['params'], {'fields': 'a,b',
+                                            'include_fields': 'false'})
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_delete_secrets(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.delete_secrets('an-id', ['a', 'b'])
+
+        args, kwargs = mock_instance.delete.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id/secrets', args[0])
+        self.assertEqual(kwargs['data'], ['a', 'b'])
+
+    @mock.patch('auth0.v3.management.hooks.RestClient')
+    def test_update_secrets(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        c = Hooks(domain='domain', token='jwttoken')
+        c.update_secrets('an-id', {'a': 'b', 'c': 'd'})
+
+        args, kwargs = mock_instance.patch.call_args
+
+        self.assertEqual('https://domain/api/v2/hooks/an-id/secrets', args[0])
+        self.assertEqual(kwargs['data'], {'a': 'b', 'c': 'd'})


### PR DESCRIPTION
### Changes

Adds the Hooks management API that was missing in auth0-python, along with unit tests.
It also includes Hooks Secrets management.

### References

API docs: https://auth0.com/docs/api/management/v2#!/Hooks/get_hooks
Closes https://github.com/auth0/auth0-python/issues/224

### Testing

- [X] This change adds unit test coverage
- [X] This change has been tested on Python 3.8

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
