### PR TITLE
Add missing user profile properties to the signup endpoint

### DIFF
--- a/auth0/v3/authentication/database.py
+++ b/auth0/v3/authentication/database.py
@@ -1,9 +1,9 @@
-from .base import AuthenticationBase
 import warnings
+
+from .base import AuthenticationBase
 
 
 class Database(AuthenticationBase):
-
     """Database & Active Directory / LDAP Authentication.
 
     Args:
@@ -35,10 +35,10 @@ class Database(AuthenticationBase):
             }
         )
 
-    def signup(self, client_id, email, password, connection, username=None,
-             user_metadata=None):
+    def signup(self, client_id, email, password, connection, username=None, user_metadata=None,
+               given_name=None, family_name=None, name=None, nickname=None, picture=None):
         """Signup using email and password.
-        
+
         Args:
            client_id (str): ID of the application to use.
 
@@ -53,6 +53,17 @@ class Database(AuthenticationBase):
            user_metadata (dict, optional): Additional key-value information to store for the user.
                     Some limitations apply, see: https://auth0.com/docs/metadata#metadata-restrictions
 
+           given_name (str, optional): The user's given name(s).
+
+           family_name (str, optional): The user's family name(s).
+
+           name (str, optional): The user's full name.
+
+           nickname (str, optional): The user's nickname.
+
+           picture (str, optional): A URI pointing to the user's picture.
+
+
         See: https://auth0.com/docs/api/authentication#signup
         """
         body = {
@@ -63,6 +74,21 @@ class Database(AuthenticationBase):
             'username': username,
             'user_metadata': user_metadata
         }
+
+        if username:
+            body.update({'username': username})
+        if user_metadata:
+            body.update({'user_metadata': user_metadata})
+        if given_name:
+            body.update({'given_name': given_name})
+        if family_name:
+            body.update({'family_name': family_name})
+        if name:
+            body.update({'name': name})
+        if nickname:
+            body.update({'nickname': nickname})
+        if picture:
+            body.update({'picture': picture})
 
         return self.post(
             'https://{}/dbconnections/signup'.format(self.domain),

--- a/auth0/v3/test/authentication/test_database.py
+++ b/auth0/v3/test/authentication/test_database.py
@@ -1,5 +1,7 @@
 import unittest
+
 import mock
+
 from ...authentication.database import Database
 
 
@@ -7,7 +9,6 @@ class TestDatabase(unittest.TestCase):
 
     @mock.patch('auth0.v3.authentication.database.Database.post')
     def test_login(self, mock_post):
-
         d = Database('my.domain.com')
 
         d.login(client_id='cid',
@@ -35,7 +36,6 @@ class TestDatabase(unittest.TestCase):
 
     @mock.patch('auth0.v3.authentication.database.Database.post')
     def test_signup(self, mock_post):
-
         d = Database('my.domain.com')
 
         # using only email and password
@@ -48,16 +48,15 @@ class TestDatabase(unittest.TestCase):
 
         self.assertEqual(args[0], 'https://my.domain.com/dbconnections/signup')
         self.assertEqual(kwargs['data'], {
-                         'client_id': 'cid',
-                         'email': 'a@b.com',
-                         'password': 'pswd',
-                         'connection': 'conn',
-                         'username': None,
-                         'user_metadata': None
-                        })
+            'client_id': 'cid',
+            'email': 'a@b.com',
+            'password': 'pswd',
+            'connection': 'conn',
+            'username': None,
+            'user_metadata': None
+        })
 
-
-        # Using also username and metadata
+        # Using also optional properties
         sample_meta = {
             'hobby': 'surfing',
             'preference': {
@@ -69,23 +68,32 @@ class TestDatabase(unittest.TestCase):
                  password='pswd',
                  connection='conn',
                  username='usr',
-                 user_metadata=sample_meta)
+                 user_metadata=sample_meta,
+                 given_name='john',
+                 family_name='doe',
+                 name='john doe',
+                 nickname='johnny',
+                 picture='avatars.com/john-doe')
 
         args, kwargs = mock_post.call_args
 
         self.assertEqual(args[0], 'https://my.domain.com/dbconnections/signup')
         self.assertEqual(kwargs['data'], {
-                         'client_id': 'cid',
-                         'email': 'a@b.com',
-                         'password': 'pswd',
-                         'connection': 'conn',
-                         'username': 'usr',
-                         'user_metadata': sample_meta
-                        })
+            'client_id': 'cid',
+            'email': 'a@b.com',
+            'password': 'pswd',
+            'connection': 'conn',
+            'username': 'usr',
+            'user_metadata': sample_meta,
+            'given_name': 'john',
+            'family_name': 'doe',
+            'name': 'john doe',
+            'nickname': 'johnny',
+            'picture': 'avatars.com/john-doe',
+        })
 
     @mock.patch('auth0.v3.authentication.database.Database.post')
     def test_change_password(self, mock_post):
-
         d = Database('my.domain.com')
 
         d.change_password(client_id='cid',


### PR DESCRIPTION
### Changes

There are extra properties that could be specified on the sign up call, documented in swagger [here](https://auth0.com/docs/api/authentication#signup). This PR adds them, defaulting to `None` when not specified.

### References

Closes https://github.com/auth0/auth0-python/issues/229

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
