### PR TITLE
Fix imports on the management/__init__.py file

### DIFF
--- a/auth0/v3/management/__init__.py
+++ b/auth0/v3/management/__init__.py
@@ -1,3 +1,4 @@
+from .auth0 import Auth0
 from .blacklists import Blacklists
 from .client_grants import ClientGrants
 from .clients import Clients

--- a/auth0/v3/management/__init__.py
+++ b/auth0/v3/management/__init__.py
@@ -1,4 +1,3 @@
-from .auth0 import Auth0
 from .blacklists import Blacklists
 from .client_grants import ClientGrants
 from .clients import Clients
@@ -11,8 +10,10 @@ from .grants import Grants
 from .guardian import Guardian
 from .hooks import Hooks
 from .jobs import Jobs
+from .log_streams import LogStreams
 from .logs import Logs
 from .resource_servers import ResourceServers
+from .roles import Roles
 from .rules import Rules
 from .rules_configs import RulesConfigs
 from .stats import Stats

--- a/auth0/v3/management/__init__.py
+++ b/auth0/v3/management/__init__.py
@@ -9,6 +9,7 @@ from .email_templates import EmailTemplates
 from .emails import Emails
 from .grants import Grants
 from .guardian import Guardian
+from .hooks import Hooks
 from .jobs import Jobs
 from .logs import Logs
 from .resource_servers import ResourceServers


### PR DESCRIPTION
### Changes

Very simple PR, more of a client developer quality-of-life change than anything, feel free to disregard if not important or wanted.

Currently, importing `Hooks` from the `management` module like so is not possible:

```python
from auth0.v3.management import Hooks
```

This is because in management's [`__init__.py`](https://github.com/auth0/auth0-python/pull/235/files#diff-48ef27daf8c04b9b512106f084418ad8), `Hooks` is not imported. It is still possible to import `Hooks` with the following code:

```python
from auth0.v3.management.hooks import Hooks
```

But when so much else is available at the `management` module level its kind of a pain.

### Testing

This is a minute change without any implications on functionality, as mentioned above just a quality of life change. Automated testing seems inappropriate, and building the package and verifying that `from auth0.v3.management import Hooks` is a valid line of code should be sufficient (if even that's necessary, since it follows the pattern of many other modules within `management`.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
