### PR TITLE
Adds a new user method invalidate_remembered_browsers

### DIFF
--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -353,3 +353,15 @@ class Users(object):
 
         url = self._url('{}/logs'.format(user_id))
         return self.client.get(url, params=params)
+
+    def invalidate_remembered_browsers(self, user_id):
+        """Invalidate all remembered browsers across all authentication factors for a user.
+
+        Args:
+            user_id (str):  The user_id to invalidate remembered browsers for.
+
+        See: https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser
+        """
+
+        url = self._url('{}/multifactor/actions/invalidate-remember-browser'.format(user_id))
+        return self.client.post(url)

--- a/auth0/v3/test/management/test_users.py
+++ b/auth0/v3/test/management/test_users.py
@@ -293,3 +293,13 @@ class TestUsers(unittest.TestCase):
         self.assertEqual(kwargs['params']['per_page'], 50)
         self.assertIsNone(kwargs['params']['sort'])
         self.assertEqual(kwargs['params']['include_totals'], 'false')
+
+    @mock.patch('auth0.v3.management.users.RestClient')
+    def test_invalidate_remembered_browsers(self, mock_rc):
+        mock_instance = mock_rc.return_value
+
+        u = Users(domain='domain', token='jwttoken')
+        u.invalidate_remembered_browsers('used_id')
+
+        args, kwargs = mock_instance.post.call_args
+        self.assertEqual('https://domain/api/v2/users/used_id/multifactor/actions/invalidate-remember-browser', args[0])

--- a/auth0/v3/test/management/test_users.py
+++ b/auth0/v3/test/management/test_users.py
@@ -299,7 +299,7 @@ class TestUsers(unittest.TestCase):
         mock_instance = mock_rc.return_value
 
         u = Users(domain='domain', token='jwttoken')
-        u.invalidate_remembered_browsers('used_id')
+        u.invalidate_remembered_browsers('user-id')
 
         args, kwargs = mock_instance.post.call_args
-        self.assertEqual('https://domain/api/v2/users/used_id/multifactor/actions/invalidate-remember-browser', args[0])
+        self.assertEqual('https://domain/api/v2/users/user-id/multifactor/actions/invalidate-remember-browser', args[0])


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Adds a missing endpoint to invalidate all remembered browsers (mfa) for a user

### References

https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
