### PR TITLE
Add support for organizations feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,74 @@ The following example demonstrates the verification of an ID token signed with t
     
 If the token verification fails, a ``TokenValidationError`` will be raised. In that scenario, the ID token should be deemed invalid and its contents should not be trusted.
 
+===========================
+Organizations (Closed Beta)
+===========================
+
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+
+Using Organizations, you can:
+* Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
+* Manage their membership in a variety of ways, including user invitation.
+* Configure branded, federated login flows for each organization.
+* Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
+* Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
+
+Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
+
+-------------------------
+Log in to an organization
+-------------------------
+
+Log in to an organization by specifying the ``organization`` property when calling ``authorize()``:
+
+.. code-block:: python
+
+    from auth0.v3.authentication.authorize_client import AuthorizeClient
+    
+    client = AuthorizeClient('my.domain.com')
+
+    client.authorize(client_id='client_id',
+                redirect_uri='http://localhost',
+                invitation="invitation_123")
+
+When logging into an organization, it is important to ensure the ``org_id`` claim of the ID Token matches the expected organization value. The ``TokenVerifier`` can be be used to ensure the ID Token contains the expected ``org_id`` claim value:
+
+.. code-block:: python
+    
+    from auth0.v3.authentication.token_verifier import TokenVerifier, AsymmetricSignatureVerifier
+    
+    domain = 'myaccount.auth0.com'
+    client_id = 'exampleid'
+    
+    # After authenticating
+    id_token = auth_result['id_token']
+    
+    jwks_url = 'https://{}/.well-known/jwks.json'.format(domain)
+    issuer = 'https://{}/'.format(domain)
+    
+    sv = AsymmetricSignatureVerifier(jwks_url)  # Reusable instance
+    tv = TokenVerifier(signature_verifier=sv, issuer=issuer, audience=client_id)
+
+    # pass the expected organization the user logged in to:
+    tv.verify(id_token, organization='org_abc')
+
+-----------------------
+Accept user invitations
+-----------------------
+
+Accept a user invitation by specifying the ``invitation`` property when calling ``authorize()``. Note that you must also specify the ``organization`` if providing an ``invitation``:
+
+.. code-block:: python
+
+    from auth0.v3.authentication.authorize_client import AuthorizeClient
+
+    client = AuthorizeClient('my.domain.com')
+
+    client.authorize(client_id='client_id',
+            redirect_uri='http://localhost',
+            organization='org_abc',
+            invitation="invitation_123")
 
 ====================
 Management SDK Usage

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ Log in to an organization by specifying the ``organization`` property when calli
 
     client.authorize(client_id='client_id',
                 redirect_uri='http://localhost',
-                invitation="invitation_123")
+                organization="org_abc")
 
 When logging into an organization, it is important to ensure the ``org_id`` claim of the ID Token matches the expected organization value. The ``TokenVerifier`` can be be used to ensure the ID Token contains the expected ``org_id`` claim value:
 
@@ -160,7 +160,8 @@ When logging into an organization, it is important to ensure the ``org_id`` clai
 Accept user invitations
 -----------------------
 
-Accept a user invitation by specifying the ``invitation`` property when calling ``authorize()``. Note that you must also specify the ``organization`` if providing an ``invitation``:
+Accept a user invitation by specifying the ``invitation`` property when calling ``authorize()``. Note that you must also specify the ``organization`` if providing an ``invitation``.
+The ID of the invitation and organization are available as query parameters on the invitation URL, e.g., ``https://your-domain.auth0.com/login?invitation=invitation_id&organization=org_id&organization_name=org_name``
 
 .. code-block:: python
 

--- a/auth0/v3/authentication/authorize_client.py
+++ b/auth0/v3/authentication/authorize_client.py
@@ -10,7 +10,7 @@ class AuthorizeClient(AuthenticationBase):
     """
 
     def authorize(self, client_id, audience=None, state=None, redirect_uri=None,
-                  response_type='code', scope='openid'):
+                  response_type='code', scope='openid', organization=None, invitation=None):
         """Authorization code grant
 
         This is the OAuth 2.0 grant that regular web apps utilize in order to access an API.
@@ -21,7 +21,9 @@ class AuthorizeClient(AuthenticationBase):
             'response_type': response_type,
             'scope': scope,
             'state': state,
-            'redirect_uri': redirect_uri
+            'redirect_uri': redirect_uri,
+            'organization': organization,
+            'invitation': invitation
         }
 
         return self.get(

--- a/auth0/v3/test/authentication/test_authorize_client.py
+++ b/auth0/v3/test/authentication/test_authorize_client.py
@@ -15,7 +15,9 @@ class TestAuthorizeClient(unittest.TestCase):
                     state='st',
                     redirect_uri='http://localhost',
                     response_type='token',
-                    scope='openid profile')
+                    scope='openid profile',
+                    organization='org_123',
+                    invitation='invitation_abc')
 
         args, kwargs = mock_get.call_args
 
@@ -26,5 +28,28 @@ class TestAuthorizeClient(unittest.TestCase):
             'state': 'st',
             'redirect_uri': 'http://localhost',
             'response_type': 'token',
-            'scope': 'openid profile'
+            'scope': 'openid profile',
+            'organization': 'org_123',
+            'invitation': 'invitation_abc'
+        })
+
+    @mock.patch('auth0.v3.authentication.authorize_client.AuthorizeClient.get')
+    def test_login_default_param_values(self, mock_get):
+
+        a = AuthorizeClient('my.domain.com')
+
+        a.authorize(client_id='cid')
+
+        args, kwargs = mock_get.call_args
+
+        self.assertEqual(args[0], 'https://my.domain.com/authorize')
+        self.assertEqual(kwargs['params'], {
+            'audience': None,
+            'invitation': None,
+            'organization':  None,
+            'redirect_uri': None,
+            'state': None,
+            'client_id': 'cid',
+            'response_type':  'code',
+            'scope': 'openid'
         })


### PR DESCRIPTION
### Changes

This PR adds support for the (beta) Organizations and User Invitations features. Changes included:

- Supports specifying the organization and invitation query parameters when using the `AuthorizeClient`.
- Supports verification of the `org_id` claim in `TokenVerifier`
- Adds documentation for using the Organizations and User Invitations features

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [X] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
