### PR TITLE
Repair Organisation get by name URL.

### DIFF
--- a/auth0/v3/management/organizations.py
+++ b/auth0/v3/management/organizations.py
@@ -57,11 +57,8 @@ class Organizations(object):
 
         See: https://auth0.com/docs/api/management/v2#!/Organizations/get_name_by_name
         """
-        params = {}
-        params['name'] = name
+        return self.client.get(self._url('name', name))
 
-        return self.client.get(self._url(), params=params)
-    
     def get_organization(self, id):
         """Retrieves an organization by its ID.
 

--- a/auth0/v3/management/organizations.py
+++ b/auth0/v3/management/organizations.py
@@ -57,7 +57,9 @@ class Organizations(object):
 
         See: https://auth0.com/docs/api/management/v2#!/Organizations/get_name_by_name
         """
-        return self.client.get(self._url('name', name))
+        params = {}
+
+        return self.client.get(self._url('name', name), params=params)
 
     def get_organization(self, id):
         """Retrieves an organization by its ID.

--- a/auth0/v3/test/management/test_organizations.py
+++ b/auth0/v3/test/management/test_organizations.py
@@ -45,7 +45,7 @@ class TestOrganizations(unittest.TestCase):
 
         args, kwargs = mock_instance.get.call_args
 
-        self.assertEqual('https://domain/api/v2/organizations', args[0])
+        self.assertEqual('https://domain/api/v2/organizations/name/test-org', args[0])
         self.assertEqual(kwargs['params'], {'name': 'test-org'})
 
     @mock.patch('auth0.v3.management.organizations.RestClient')

--- a/auth0/v3/test/management/test_organizations.py
+++ b/auth0/v3/test/management/test_organizations.py
@@ -46,7 +46,7 @@ class TestOrganizations(unittest.TestCase):
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/organizations/name/test-org', args[0])
-        self.assertEqual(kwargs['params'], {'name': 'test-org'})
+        self.assertEqual(kwargs['params'], {})
 
     @mock.patch('auth0.v3.management.organizations.RestClient')
     def test_get_organization(self, mock_rc):


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
There is an error in `organizations.get_organization_by_name`. The path from the docs should be `/api/v2/organizations/name/{name}`. The current implementation, however, just uses the default `/api/v2/organizations` and sends the `name` parameter (which is invalid and throws an error).

### References

Please include relevant links supporting this change such as a:

- Pull request https://github.com/auth0/auth0-python/issues/268
- [API documentation](https://auth0.com/docs/api/management/v2#!/Organizations/get_name_by_name)

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

I'm sorry but I can't see how to run the existing test. Please point me to the instructions and I'll update the PR.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
