### PR TITLE
Re-Route Job Results endpoint

### DIFF
--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -1,4 +1,5 @@
 from .rest import RestClient
+import warnings
 
 
 class Jobs(object):
@@ -56,10 +57,14 @@ class Jobs(object):
         Args:
             job_id (str): The id of the job.
 
-        See: https://auth0.com/docs/api/management/v2#!/Jobs/get_results
+        Deprecation: 
+            The /jobs/{id}/results endpoint was removed from the Management API.
+            You can obtain the Job results by querying a Job by ID.
+            
+        See: https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id
         """
-        url = self._url('%s/results' % job_id)
-        return self.client.get(url)
+        warnings.warn("/jobs/{id}/results is no longer available. The get(id) function will be called instead.", DeprecationWarning)
+        return self.get(job_id)
 
     def export_users(self, body):
         """Export all users to a file using a long running job.

--- a/auth0/v3/test/management/test_jobs.py
+++ b/auth0/v3/test/management/test_jobs.py
@@ -23,25 +23,26 @@ class TestJobs(unittest.TestCase):
         )
 
     @mock.patch('auth0.v3.management.jobs.RestClient')
-    def get_failed_job(self, mock_rc):
+    def test_get_failed_job(self, mock_rc):
         mock_instance = mock_rc.return_value
 
         j = Jobs(domain='domain', token='jwttoken')
-        j.get('an-id')
+        j.get_failed_job('an-id')
 
         mock_instance.get.assert_called_with(
             'https://domain/api/v2/jobs/an-id/errors',
         )
 
     @mock.patch('auth0.v3.management.jobs.RestClient')
-    def get_job_results(self, mock_rc):
+    def test_get_job_results(self, mock_rc):
         mock_instance = mock_rc.return_value
 
         j = Jobs(domain='domain', token='jwttoken')
         j.get('an-id')
 
+        # Should use the 'get by id' URL
         mock_instance.get.assert_called_with(
-            'https://domain/api/v2/jobs/an-id/results',
+            'https://domain/api/v2/jobs/an-id',
         )
 
     @mock.patch('auth0.v3.management.jobs.RestClient')

--- a/auth0/v3/test/management/test_jobs.py
+++ b/auth0/v3/test/management/test_jobs.py
@@ -38,7 +38,7 @@ class TestJobs(unittest.TestCase):
         mock_instance = mock_rc.return_value
 
         j = Jobs(domain='domain', token='jwttoken')
-        j.get('an-id')
+        j.get_results('an-id')
 
         # Should use the 'get by id' URL
         mock_instance.get.assert_called_with(


### PR DESCRIPTION
### Changes

It appears like the endpoint to get a job's result has been removed from the Management API2 definition. While the endpoint is no longer accessible, the function call can be re-routed to the existing get-job-by-id function, which would yield the job status along with their results

### References

See #274 

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
