### PR TITLE
Moves docs for each method into the method itself

### DIFF
--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -227,7 +227,7 @@ class TokenVerifier():
             nonce (str, optional): The nonce value sent during authentication.
             max_age (int, optional): The max_age value sent during authentication.
             organization (str, optional): The expected organization ID (org_id) claim value. This should be specified
-                when logging in to an organization.
+            when logging in to an organization.
 
         Raises:
             TokenValidationError: when the token cannot be decoded, the token signing algorithm is not the expected one,

--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -1,3 +1,4 @@
+"""Token Verifier module"""
 import json
 import time
 
@@ -8,6 +9,13 @@ from auth0.v3.exceptions import TokenValidationError
 
 
 class SignatureVerifier(object):
+    """Abstract class that will verify a given JSON web token's signature
+    using the key fetched internally given its key id.
+
+    Args:
+        algorithm (str): The expected signing algorithm (e.g. RS256).
+    """
+
     DISABLE_JWT_CHECKS = {
         "verify_signature": True,
         "verify_exp": False,
@@ -20,42 +28,33 @@ class SignatureVerifier(object):
         "require_nbf": False,
     }
 
-    """Abstract class that will verify a given JSON web token's signature
-    using the key fetched internally given its key id.
-    
-    Args:
-        algorithm (str): The expected signing algorithm (e.g. RS256).
-    """
-
     def __init__(self, algorithm):
         if not algorithm or type(algorithm) != str:
             raise ValueError("algorithm must be specified.")
         self._algorithm = algorithm
 
-    """Obtains the key associated to the given key id.
-    Must be implemented by subclasses.
-
-    Args:
-        key_id (str, optional): The id of the key to fetch.
-    
-    Returns:
-        the key to use for verifying a cryptographic signature
-    """
-
     def _fetch_key(self, key_id=None):
+        """Obtains the key associated to the given key id.
+        Must be implemented by subclasses.
+
+        Args:
+            key_id (str, optional): The id of the key to fetch.
+
+        Returns:
+            the key to use for verifying a cryptographic signature
+        """
         raise NotImplementedError
 
-    """Verifies the signature of the given JSON web token.
-
-    Args:
-        token (str): The JWT to get its signature verified.
-
-    Raises:
-        TokenValidationError: if the token cannot be decoded, the algorithm is invalid
-        or the token's signature doesn't match the calculated one.
-    """
-
     def verify_signature(self, token):
+        """Verifies the signature of the given JSON web token.
+
+        Args:
+            token (str): The JWT to get its signature verified.
+
+        Raises:
+            TokenValidationError: if the token cannot be decoded, the algorithm is invalid
+            or the token's signature doesn't match the calculated one.
+        """
         try:
             header = jwt.get_unverified_header(token)
         except jwt.exceptions.DecodeError:
@@ -111,8 +110,6 @@ class AsymmetricSignatureVerifier(SignatureVerifier):
 
 
 class JwksFetcher(object):
-    CACHE_TTL = 600  # 10 min cache lifetime
-
     """Class that fetches and holds a JSON web key set.
     This class makes use of an in-memory cache. For it to work properly, define this instance once and re-use it.
 
@@ -120,6 +117,8 @@ class JwksFetcher(object):
         jwks_url (str): The url where the JWK set is located.
         cache_ttl (str, optional): The lifetime of the JWK set cache in seconds. Defaults to 600 seconds.
     """
+
+    CACHE_TTL = 600  # 10 min cache lifetime
 
     def __init__(self, jwks_url, cache_ttl=CACHE_TTL):
         self._jwks_url = jwks_url
@@ -132,15 +131,14 @@ class JwksFetcher(object):
         self._cache_ttl = cache_ttl
         self._cache_is_fresh = False
 
-    """Attempts to obtain the JWK set from the cache, as long as it's still valid.
-    When not, it will perform a network request to the jwks_url to obtain a fresh result
-    and update the cache value with it.
-
-    Args:
-        force (bool, optional): whether to ignore the cache and force a network request or not. Defaults to False.
-    """
-
     def _fetch_jwks(self, force=False):
+        """Attempts to obtain the JWK set from the cache, as long as it's still valid.
+        When not, it will perform a network request to the jwks_url to obtain a fresh result
+        and update the cache value with it.
+
+        Args:
+            force (bool, optional): whether to ignore the cache and force a network request or not. Defaults to False.
+        """
         has_expired = self._cache_date + self._cache_ttl < time.time()
 
         if not force and not has_expired:
@@ -160,11 +158,11 @@ class JwksFetcher(object):
             self._cache_date = time.time()
         return self._cache_value
 
-    """Converts a JWK string representation into a binary certificate in PEM format.
-    """
-
     @staticmethod
     def _parse_jwks(jwks):
+        """
+        Converts a JWK string representation into a binary certificate in PEM format.
+        """
         keys = {}
 
         for key in jwks['keys']:
@@ -174,19 +172,19 @@ class JwksFetcher(object):
             keys[key["kid"]] = rsa_key
         return keys
 
-    """Obtains the JWK associated with the given key id.
-
-    Args:
-        key_id (str): The id of the key to fetch.
-
-    Returns:
-        the JWK associated with the given key id.
-    
-    Raises:
-        TokenValidationError: when a key with that id cannot be found
-    """
 
     def get_key(self, key_id):
+        """Obtains the JWK associated with the given key id.
+
+        Args:
+            key_id (str): The id of the key to fetch.
+
+        Returns:
+            the JWK associated with the given key id.
+
+        Raises:
+            TokenValidationError: when a key with that id cannot be found
+        """
         keys = self._fetch_jwks()
 
         if keys and key_id in keys:
@@ -221,21 +219,21 @@ class TokenVerifier():
         self._sv = signature_verifier
         self._clock = None  # visible for testing
 
-    """Attempts to verify the given ID token, following the steps defined in the OpenID Connect spec.
-
-    Args:
-        token (str): The JWT to verify.
-        nonce (str, optional): The nonce value sent during authentication.
-        max_age (int, optional): The max_age value sent during authentication.
-        organization (str, optional): The expected organization ID (org_id) claim value. This should be specified
-            when logging in to an organization.
-        
-    Raises:
-        TokenValidationError: when the token cannot be decoded, the token signing algorithm is not the expected one, 
-        the token signature is invalid or the token has a claim missing or with unexpected value.
-    """
-
     def verify(self, token, nonce=None, max_age=None, organization=None):
+        """Attempts to verify the given ID token, following the steps defined in the OpenID Connect spec.
+
+        Args:
+            token (str): The JWT to verify.
+            nonce (str, optional): The nonce value sent during authentication.
+            max_age (int, optional): The max_age value sent during authentication.
+            organization (str, optional): The expected organization ID (org_id) claim value. This should be specified
+                when logging in to an organization.
+
+        Raises:
+            TokenValidationError: when the token cannot be decoded, the token signing algorithm is not the expected one,
+            the token signature is invalid or the token has a claim missing or with unexpected value.
+        """
+
         # Verify token presence
         if not token or not isinstance(token, str):
             raise TokenValidationError("ID token is required but missing.")


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

These changes don't change code, this only corrects the placement of the docstrings for each method and classes on `authentication.token_verifier`

### References

fixes #282 

### Testing

Run the `make html` for regenarating the docs then navigate to the `authentication.token_verifier` part, now you'll see the corresponding documentation:

<img width="734" alt="Screen Shot 2021-08-13 at 09 51 21" src="https://user-images.githubusercontent.com/6595551/129359732-f4afb1bd-c84a-4c12-86c0-f43c898b28aa.png">


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
