### PR TITLE
Implement AccessTokenVerifier class

### DIFF
--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -449,11 +449,11 @@ class AccessTokenVerifier():
 
         # Scopes
         if scopes:
-            if 'scopes' not in payload or not isinstance(payload['scopes'], (str, ustr)):
+            if 'scope' not in payload or not isinstance(payload['scope'], (str, ustr)):
                 raise TokenValidationError('No scopes claim found in token.')
 
             for scope in scopes.split(' '):
-                if scope not in payload['scopes'].split(' '):
+                if scope not in payload['scope'].split(' '):
                     msg = "Insufficient scope."
                     raise Auth0Error(status_code=403, error_code='insufficient_scope', message=msg)
 

--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -381,6 +381,9 @@ class AccessTokenVerifier():
         Raises:
             TokenValidationError: when the token cannot be decoded, the token signing algorithm is not the expected one,
             the token signature is invalid or the token has a claim missing or with unexpected value.
+
+        Returns:
+            If all checks pass, the token payload is returned
         """
 
         # Verify token presence
@@ -392,6 +395,8 @@ class AccessTokenVerifier():
 
         # Verify claims
         self._verify_payload(payload, scopes, permissions)
+
+        return payload
 
     def _verify_payload(self, payload, scopes=None, permissions=None):
         try:

--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -465,4 +465,4 @@ class AccessTokenVerifier():
             for permission in permissions:
                 if permission not in payload['permissions']:
                     msg = "You don't have access to this resource"
-                    raise Auth0Error(status_code=403, error_code=403, message=msg)
+                    raise Auth0Error(status_code=403, error_code='forbidden', message=msg)

--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -449,7 +449,7 @@ class AccessTokenVerifier():
 
         # Scopes
         if scopes:
-            if 'scopes' not in payload or not isinstance(payload['scopes'], str):
+            if 'scopes' not in payload or not isinstance(payload['scopes'], (str, ustr)):
                 raise TokenValidationError('No scopes claim found in token.')
 
             for scope in scopes.split(' '):

--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -375,8 +375,8 @@ class AccessTokenVerifier():
 
         Args:
             token (str): The JWT access token to verify.
-            scopes (list(str), optional): a list of scopes to verify.
-            permissions (list(str), optional): a list of permissions to verify.
+            scopes (str, optional): A string of scopes to verify.
+            permissions (list(str), optional): A list of permissions to verify.
 
         Raises:
             TokenValidationError: when the token cannot be decoded, the token signing algorithm is not the expected one,

--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -454,8 +454,8 @@ class AccessTokenVerifier():
 
             for scope in scopes.split(' '):
                 if scope not in payload['scopes'].split(' '):
-                    msg = "The requested scope is invalid, unknown, malformed, or exceeds the scope granted by the resource owner."
-                    raise Auth0Error(status_code=400, error_code='invalid_scope', message=msg)
+                    msg = "Insufficient scope."
+                    raise Auth0Error(status_code=403, error_code='insufficient_scope', message=msg)
 
         # Permissions
         if permissions:

--- a/auth0/v3/authentication/token_verifier.py
+++ b/auth0/v3/authentication/token_verifier.py
@@ -454,8 +454,8 @@ class AccessTokenVerifier():
 
             for scope in scopes.split(' '):
                 if scope not in payload['scopes'].split(' '):
-                    msg = "You don't have access to this resource"
-                    raise Auth0Error(status_code=401, error_code=401, message=msg)
+                    msg = "The requested scope is invalid, unknown, malformed, or exceeds the scope granted by the resource owner."
+                    raise Auth0Error(status_code=400, error_code='invalid_scope', message=msg)
 
         # Permissions
         if permissions:

--- a/auth0/v3/test/authentication/test_token_verifier.py
+++ b/auth0/v3/test/authentication/test_token_verifier.py
@@ -608,4 +608,4 @@ class TestAccessTokenVerifier(unittest.TestCase):
 
     def test_fails_when_scopes_specified_but_does_not_mactch(self):
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHxzZGs0NThma3MiLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwiaXNzIjoiaHR0cHM6Ly90b2tlbnMtdGVzdC5hdXRoMC5jb20vIiwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsInNjb3BlcyI6InNjb3BlOm9uZSBzY29wZTp0d28ifQ.PROQRTvGrFGkQp-P1FARX5hEUI2ePWyREaw_zwCbzlo"
-        self.assert_fails_with_auth0_error(token, "401: You don't have access to this resource", signature_verifier=SymmetricSignatureVerifier(HMAC_SHARED_SECRET), scopes='scope:three')
+        self.assert_fails_with_auth0_error(token, "400: The requested scope is invalid, unknown, malformed, or exceeds the scope granted by the resource owner.", signature_verifier=SymmetricSignatureVerifier(HMAC_SHARED_SECRET), scopes='scope:three')

--- a/auth0/v3/test/authentication/test_token_verifier.py
+++ b/auth0/v3/test/authentication/test_token_verifier.py
@@ -608,4 +608,4 @@ class TestAccessTokenVerifier(unittest.TestCase):
 
     def test_fails_when_scopes_specified_but_does_not_mactch(self):
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHxzZGs0NThma3MiLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwiaXNzIjoiaHR0cHM6Ly90b2tlbnMtdGVzdC5hdXRoMC5jb20vIiwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsInNjb3BlcyI6InNjb3BlOm9uZSBzY29wZTp0d28ifQ.PROQRTvGrFGkQp-P1FARX5hEUI2ePWyREaw_zwCbzlo"
-        self.assert_fails_with_auth0_error(token, "400: The requested scope is invalid, unknown, malformed, or exceeds the scope granted by the resource owner.", signature_verifier=SymmetricSignatureVerifier(HMAC_SHARED_SECRET), scopes='scope:three')
+        self.assert_fails_with_auth0_error(token, "403: Insufficient scope.", signature_verifier=SymmetricSignatureVerifier(HMAC_SHARED_SECRET), scopes='scope:three')

--- a/auth0/v3/test/authentication/test_token_verifier.py
+++ b/auth0/v3/test/authentication/test_token_verifier.py
@@ -592,7 +592,7 @@ class TestAccessTokenVerifier(unittest.TestCase):
         tv.verify(token)
 
     def test_passes_when_scopes_present_and_matches(self):
-        token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHxzZGs0NThma3MiLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwiaXNzIjoiaHR0cHM6Ly90b2tlbnMtdGVzdC5hdXRoMC5jb20vIiwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsInNjb3BlcyI6InNjb3BlOm9uZSBzY29wZTp0d28ifQ.PROQRTvGrFGkQp-P1FARX5hEUI2ePWyREaw_zwCbzlo"
+        token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHxzZGs0NThma3MiLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwiaXNzIjoiaHR0cHM6Ly90b2tlbnMtdGVzdC5hdXRoMC5jb20vIiwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsInNjb3BlIjoic2NvcGU6b25lIHNjb3BlOnR3byJ9.kNZzMYNyYeVG1vbBuGAgjWdMhv8C2iYHWlJ9BWSYTkA"
         sv = SymmetricSignatureVerifier(HMAC_SHARED_SECRET)
         tv = AccessTokenVerifier(
             signature_verifier=sv,
@@ -607,5 +607,5 @@ class TestAccessTokenVerifier(unittest.TestCase):
         self.assert_fails_with_token_error(token, "No scopes claim found in token.", signature_verifier=SymmetricSignatureVerifier(HMAC_SHARED_SECRET), scopes='scope:three')
 
     def test_fails_when_scopes_specified_but_does_not_mactch(self):
-        token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHxzZGs0NThma3MiLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwiaXNzIjoiaHR0cHM6Ly90b2tlbnMtdGVzdC5hdXRoMC5jb20vIiwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsInNjb3BlcyI6InNjb3BlOm9uZSBzY29wZTp0d28ifQ.PROQRTvGrFGkQp-P1FARX5hEUI2ePWyREaw_zwCbzlo"
+        token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHxzZGs0NThma3MiLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwiaXNzIjoiaHR0cHM6Ly90b2tlbnMtdGVzdC5hdXRoMC5jb20vIiwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsInNjb3BlIjoic2NvcGU6b25lIHNjb3BlOnR3byJ9.kNZzMYNyYeVG1vbBuGAgjWdMhv8C2iYHWlJ9BWSYTkA"
         self.assert_fails_with_auth0_error(token, "403: Insufficient scope.", signature_verifier=SymmetricSignatureVerifier(HMAC_SHARED_SECRET), scopes='scope:three')


### PR DESCRIPTION
### Changes

- Class added: `AccessTokenVerifier`

This class implements all the logic in our decorators for Python API quick starts. This aims to solve the issue of having to copy more than 150 lines of code, now instead people would install the python SDK and follow the example below in their endpoints/methods:

```python
from auth0.v3.authentication.token_verifier import (
    AccessTokenVerifier, SymmetricSignatureVerifier
)

from auth0.v3.exceptions import Auth0Error, TokenValidationError

sig_verifier = SymmetricSignatureVerifier('secret')

expected_issuer = 'https://tokens-test.auth0.com/'

api_audience = 'http://audience.test'

token_verifier = AccessTokenVerifier(
    signature_verifier=sig_verifier,
    issuer=expected_issuer,
    audience=api_audience
)

token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHxzZGs0NThma3MiLCJhdWQiOiJodHRwOi8vYXVkaWVuY2UudGVzdCIsImlzcyI6Imh0dHBzOi8vdG9rZW5zLXRlc3QuYXV0aDAuY29tLyIsImV4cCI6MTY4Nzc2NTM2MSwiaWF0IjoxNTg3NTkyNTYxLCJzY29wZSI6InNjb3BlOm9uZSBzY29wZTp0d28iLCJwZXJtaXNzaW9ucyI6WyJzY29wZTp0d28iXX0.AYakukIxuyfIuPxVAXGYmmLMHiBiahEBcSStjWr07BE'

# No error should be raised here
try:
    token_verifier.verify(token, permissions=['scope:two'], scopes='scope:one')
except TokenValidationError as error:
    print(error)
finally:
    print('Verification successful! Correct Permissions and scopes')

# The Auth0Error for wrong permissions should be raised
try:
    token_verifier.verify(token, permissions=['scope:three'])
except Auth0Error as error:
    print(error)

# The Auth0Error for wrong scopes should be raised
try:
    token_verifier.verify(token, scopes='scope:three')
except Auth0Error as error:
    print(error)

# Results
# Verification successful! Correct Permissions and scopes
# 403: You don't have access to this resource
# 403: Insufficient scope.
```

- Any alternative designs or approaches considered: I copied most of the code from the `TokenVerifier` class and I believe a refactor for avoiding code repetition would be something good to do, but I didn't want to do it in this PR as per the [Auth0 Contribution Guide directive on Pull Requests](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md#pull-requests).

### References

This is based on me copying code for the quickstarts for every sample I did so far, so this creates a class that can hold all the logic for validating an Auth0 Access Token

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage (I'm not sure how to run those so I left it unchecked)
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors

<img width="236" alt="Screen Shot 2021-08-16 at 15 37 17" src="https://user-images.githubusercontent.com/6595551/129613186-de785276-f32a-43ec-a882-f91f572ce212.png">

Also, I left a few comments (review process) on the errors raised for permissions and scopes as I was not sure about their messages.

PS.: the edit was to make the example more complete 😉 