### PR TITLE
[SDK-2687] Implement automatic rate-limit handling

### DIFF
--- a/auth0/v3/management/auth0.py
+++ b/auth0/v3/management/auth0.py
@@ -32,31 +32,36 @@ class Auth0(object):
         domain (str): Your Auth0 domain, e.g: 'username.auth0.com'
 
         token (str): Management API v2 Token
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token):
-        self.blacklists = Blacklists(domain, token)
-        self.client_grants = ClientGrants(domain, token)
-        self.clients = Clients(domain, token)
-        self.connections = Connections(domain, token)
-        self.custom_domains = CustomDomains(domain, token)
-        self.device_credentials = DeviceCredentials(domain, token)
-        self.email_templates = EmailTemplates(domain, token)
-        self.emails = Emails(domain, token)
-        self.grants = Grants(domain, token)
-        self.guardian = Guardian(domain, token)
-        self.hooks = Hooks(domain, token)
-        self.jobs = Jobs(domain, token)
-        self.log_streams = LogStreams(domain, token)
-        self.logs = Logs(domain, token)
-        self.organizations = Organizations(domain, token)
-        self.resource_servers = ResourceServers(domain, token)
-        self.roles = Roles(domain, token)
-        self.rules_configs = RulesConfigs(domain, token)
-        self.rules = Rules(domain, token)
-        self.stats = Stats(domain, token)
-        self.tenants = Tenants(domain, token)
-        self.tickets = Tickets(domain, token)
-        self.user_blocks = UserBlocks(domain, token)
-        self.users_by_email = UsersByEmail(domain, token)
-        self.users = Users(domain, token)
+    def __init__(self, domain, token, rest_options=None):
+        self.blacklists = Blacklists(domain=domain, token=token, rest_options=rest_options)
+        self.client_grants = ClientGrants(domain=domain, token=token, rest_options=rest_options)
+        self.clients = Clients(domain=domain, token=token, rest_options=rest_options)
+        self.connections = Connections(domain=domain, token=token, rest_options=rest_options)
+        self.custom_domains = CustomDomains(domain=domain, token=token, rest_options=rest_options)
+        self.device_credentials = DeviceCredentials(domain=domain, token=token, rest_options=rest_options)
+        self.email_templates = EmailTemplates(domain=domain, token=token, rest_options=rest_options)
+        self.emails = Emails(domain=domain, token=token, rest_options=rest_options)
+        self.grants = Grants(domain=domain, token=token, rest_options=rest_options)
+        self.guardian = Guardian(domain=domain, token=token, rest_options=rest_options)
+        self.hooks = Hooks(domain=domain, token=token, rest_options=rest_options)
+        self.jobs = Jobs(domain=domain, token=token, rest_options=rest_options)
+        self.log_streams = LogStreams(domain=domain, token=token, rest_options=rest_options)
+        self.logs = Logs(domain=domain, token=token, rest_options=rest_options)
+        self.organizations = Organizations(domain=domain, token=token, rest_options=rest_options)
+        self.resource_servers = ResourceServers(domain=domain, token=token, rest_options=rest_options)
+        self.roles = Roles(domain=domain, token=token, rest_options=rest_options)
+        self.rules_configs = RulesConfigs(domain=domain, token=token, rest_options=rest_options)
+        self.rules = Rules(domain=domain, token=token, rest_options=rest_options)
+        self.stats = Stats(domain=domain, token=token, rest_options=rest_options)
+        self.tenants = Tenants(domain=domain, token=token, rest_options=rest_options)
+        self.tickets = Tickets(domain=domain, token=token, rest_options=rest_options)
+        self.user_blocks = UserBlocks(domain=domain, token=token, rest_options=rest_options)
+        self.users_by_email = UsersByEmail(domain=domain, token=token, rest_options=rest_options)
+        self.users = Users(domain=domain, token=token, rest_options=rest_options)

--- a/auth0/v3/management/blacklists.py
+++ b/auth0/v3/management/blacklists.py
@@ -16,11 +16,16 @@ class Blacklists(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.url = '{}://{}/api/v2/blacklists/tokens'.format(protocol, domain)
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def get(self, aud=None):
         """Retrieves the jti and aud of all tokens in the blacklist.

--- a/auth0/v3/management/client_grants.py
+++ b/auth0/v3/management/client_grants.py
@@ -16,12 +16,17 @@ class ClientGrants(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/client-grants'.format(self.protocol, self.domain)

--- a/auth0/v3/management/clients.py
+++ b/auth0/v3/management/clients.py
@@ -16,12 +16,17 @@ class Clients(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/clients'.format(self.protocol, self.domain)

--- a/auth0/v3/management/connections.py
+++ b/auth0/v3/management/connections.py
@@ -16,12 +16,17 @@ class Connections(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/connections'.format(self.protocol, self.domain)

--- a/auth0/v3/management/custom_domains.py
+++ b/auth0/v3/management/custom_domains.py
@@ -16,12 +16,17 @@ class CustomDomains(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/custom-domains'.format(self.protocol, self.domain)

--- a/auth0/v3/management/device_credentials.py
+++ b/auth0/v3/management/device_credentials.py
@@ -16,12 +16,17 @@ class DeviceCredentials(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/device-credentials'.format(self.protocol, self.domain)

--- a/auth0/v3/management/email_templates.py
+++ b/auth0/v3/management/email_templates.py
@@ -16,12 +16,17 @@ class EmailTemplates(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/email-templates'.format(self.protocol, self.domain)

--- a/auth0/v3/management/emails.py
+++ b/auth0/v3/management/emails.py
@@ -16,12 +16,17 @@ class Emails(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/emails/provider'.format(self.protocol, self.domain)

--- a/auth0/v3/management/grants.py
+++ b/auth0/v3/management/grants.py
@@ -16,12 +16,17 @@ class Grants(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/grants'.format(self.protocol, self.domain)
@@ -45,7 +50,7 @@ class Grants(object):
            extra_params (dictionary, optional): The extra parameters to add to
                the request. The page, per_page, and include_totals values
                specified as parameters take precedence over the ones defined here.
-            
+
         See: https://auth0.com/docs/api/management/v2#!/Grants/get_grants
         """
         params = extra_params or {}

--- a/auth0/v3/management/guardian.py
+++ b/auth0/v3/management/guardian.py
@@ -16,12 +16,17 @@ class Guardian(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/guardian'.format(self.protocol, self.domain)
@@ -33,7 +38,7 @@ class Guardian(object):
         """Retrieves all factors. Useful to check factor enablement and
              trial status.
 
-        See: https://auth0.com/docs/api/management/v2#!/Guardian/get_factors                 
+        See: https://auth0.com/docs/api/management/v2#!/Guardian/get_factors
         """
 
         return self.client.get(self._url('factors'))

--- a/auth0/v3/management/hooks.py
+++ b/auth0/v3/management/hooks.py
@@ -17,12 +17,17 @@ class Hooks(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = "{}://{}/api/v2/hooks".format(self.protocol, self.domain)

--- a/auth0/v3/management/jobs.py
+++ b/auth0/v3/management/jobs.py
@@ -17,12 +17,17 @@ class Jobs(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, path=None):
         url = '{}://{}/api/v2/jobs'.format(self.protocol, self.domain)
@@ -57,10 +62,10 @@ class Jobs(object):
         Args:
             job_id (str): The id of the job.
 
-        Deprecation: 
+        Deprecation:
             The /jobs/{id}/results endpoint was removed from the Management API.
             You can obtain the Job results by querying a Job by ID.
-            
+
         See: https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id
         """
         warnings.warn("/jobs/{id}/results is no longer available. The get(id) function will be called instead.", DeprecationWarning)

--- a/auth0/v3/management/log_streams.py
+++ b/auth0/v3/management/log_streams.py
@@ -16,12 +16,17 @@ class LogStreams(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/log-streams'.format(self.protocol, self.domain)

--- a/auth0/v3/management/logs.py
+++ b/auth0/v3/management/logs.py
@@ -16,12 +16,17 @@ class Logs(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/logs'.format(self.protocol, self.domain)

--- a/auth0/v3/management/organizations.py
+++ b/auth0/v3/management/organizations.py
@@ -16,12 +16,17 @@ class Organizations(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, *args):
         url = '{}://{}/api/v2/organizations'.format(self.protocol, self.domain)

--- a/auth0/v3/management/resource_servers.py
+++ b/auth0/v3/management/resource_servers.py
@@ -16,12 +16,17 @@ class ResourceServers(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/resource-servers'.format(self.protocol, self.domain)

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -123,13 +123,7 @@ class RestClient(object):
         self._metrics = {'retries': 0, 'backoff': []}
 
         # Cap the maximum number of retries to 10 or fewer. Floor the retries at 0.
-        retries = 3
-
-        if self.options is not None:
-            if self.options.retries is not None:
-                retries = self.options.retries
-
-        retries = min(self.MAX_REQUEST_RETRIES(), max(0, retries))
+        retries = min(self.MAX_REQUEST_RETRIES(), max(0, self.options.retries))
 
         while True:
             # Increment attempt number

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -93,16 +93,16 @@ class RestClient(object):
             # Retry the request. Apply a exponential backoff for subsequent attempts, using this formula:
             # max(MIN_REQUEST_RETRY_DELAY, min(MAX_REQUEST_RETRY_DELAY, (100ms * (2 ** attempt - 1)) + random_between(1, MAX_REQUEST_RETRY_JITTER)))
 
-            # ✔ Increases base delay by (100ms * (2 ** attempt - 1))
+            # Increases base delay by (100ms * (2 ** attempt - 1))
             wait = 100 * 2 ** (attempt - 1)
 
-            # ✔ Introduces jitter to the base delay; increases delay between 1ms to MAX_REQUEST_RETRY_JITTER (100ms)
+            # Introduces jitter to the base delay; increases delay between 1ms to MAX_REQUEST_RETRY_JITTER (100ms)
             wait += randint(1, self.MAX_REQUEST_RETRY_JITTER())
 
-            # ✔ Is never more than MAX_REQUEST_RETRY_DELAY (1s)
+            # Is never more than MAX_REQUEST_RETRY_DELAY (1s)
             wait = min(self.MAX_REQUEST_RETRY_DELAY(), wait)
 
-            # ✔ Is never less than MIN_REQUEST_RETRY_DELAY (100ms)
+            # Is never less than MIN_REQUEST_RETRY_DELAY (100ms)
             wait = max(self.MIN_REQUEST_RETRY_DELAY(), wait)
 
             self._metrics['retries'] = attempt

--- a/auth0/v3/management/roles.py
+++ b/auth0/v3/management/roles.py
@@ -16,12 +16,17 @@ class Roles(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/roles'.format(self.protocol, self.domain)

--- a/auth0/v3/management/rules.py
+++ b/auth0/v3/management/rules.py
@@ -16,12 +16,17 @@ class Rules(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/rules'.format(self.protocol, self.domain)

--- a/auth0/v3/management/rules_configs.py
+++ b/auth0/v3/management/rules_configs.py
@@ -16,12 +16,17 @@ class RulesConfigs(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/rules-configs'.format(self.protocol, self.domain)

--- a/auth0/v3/management/stats.py
+++ b/auth0/v3/management/stats.py
@@ -16,12 +16,17 @@ class Stats(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, action):
         return '{}://{}/api/v2/stats/{}'.format(self.protocol, self.domain, action)

--- a/auth0/v3/management/tenants.py
+++ b/auth0/v3/management/tenants.py
@@ -16,12 +16,17 @@ class Tenants(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self):
         return '{}://{}/api/v2/tenants/settings'.format(self.protocol, self.domain)
@@ -36,7 +41,7 @@ class Tenants(object):
 
            include_fields (bool, optional): True if the fields specified are
               to be included in the result, False otherwise. Defaults to True.
-              
+
         See: https://auth0.com/docs/api/management/v2#!/Tenants/get_settings
         """
 

--- a/auth0/v3/management/tickets.py
+++ b/auth0/v3/management/tickets.py
@@ -16,12 +16,17 @@ class Tickets(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, action):
         return '{}://{}/api/v2/tickets/{}'.format(self.protocol, self.domain, action)

--- a/auth0/v3/management/user_blocks.py
+++ b/auth0/v3/management/user_blocks.py
@@ -16,12 +16,17 @@ class UserBlocks(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/user-blocks'.format(self.protocol, self.domain)

--- a/auth0/v3/management/users.py
+++ b/auth0/v3/management/users.py
@@ -18,12 +18,17 @@ class Users(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self, id=None):
         url = '{}://{}/api/v2/users'.format(self.protocol, self.domain)

--- a/auth0/v3/management/users_by_email.py
+++ b/auth0/v3/management/users_by_email.py
@@ -16,12 +16,17 @@ class UsersByEmail(object):
             connect and read timeout. Pass a tuple to specify
             both values separately or a float to set both to it.
             (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
     """
 
-    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https"):
+    def __init__(self, domain, token, telemetry=True, timeout=5.0, protocol="https", rest_options=None):
         self.domain = domain
         self.protocol = protocol
-        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout)
+        self.client = RestClient(jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options)
 
     def _url(self):
         url = '{}://{}/api/v2/users-by-email'.format(self.protocol, self.domain)

--- a/auth0/v3/test/management/test_blacklists.py
+++ b/auth0/v3/test/management/test_blacklists.py
@@ -7,7 +7,7 @@ class TestBlacklists(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Blacklists(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_client_grants.py
+++ b/auth0/v3/test/management/test_client_grants.py
@@ -7,7 +7,7 @@ class TestClientGrants(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = ClientGrants(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_clients.py
+++ b/auth0/v3/test/management/test_clients.py
@@ -7,7 +7,7 @@ class TestClients(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Clients(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_connections.py
+++ b/auth0/v3/test/management/test_connections.py
@@ -7,7 +7,7 @@ class TestConnection(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Connections(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_custom_domains.py
+++ b/auth0/v3/test/management/test_custom_domains.py
@@ -7,7 +7,7 @@ class TestCustomDomains(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = CustomDomains(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_device_credentials.py
+++ b/auth0/v3/test/management/test_device_credentials.py
@@ -7,7 +7,7 @@ class TestDeviceCredentials(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = DeviceCredentials(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_email_endpoints.py
+++ b/auth0/v3/test/management/test_email_endpoints.py
@@ -7,7 +7,7 @@ class TestClients(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = EmailTemplates(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_emails.py
+++ b/auth0/v3/test/management/test_emails.py
@@ -7,7 +7,7 @@ class TestEmails(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Emails(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_grants.py
+++ b/auth0/v3/test/management/test_grants.py
@@ -7,7 +7,7 @@ class TestGrants(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Grants(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_guardian.py
+++ b/auth0/v3/test/management/test_guardian.py
@@ -7,7 +7,7 @@ class TestGuardian(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Guardian(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_hooks.py
+++ b/auth0/v3/test/management/test_hooks.py
@@ -7,7 +7,7 @@ class TestRules(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Hooks(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_jobs.py
+++ b/auth0/v3/test/management/test_jobs.py
@@ -7,7 +7,7 @@ class TestJobs(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Jobs(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_log_streams.py
+++ b/auth0/v3/test/management/test_log_streams.py
@@ -9,7 +9,7 @@ class TestLogStreams(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = LogStreams(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 
@@ -24,7 +24,7 @@ class TestLogStreams(unittest.TestCase):
         args, kwargs = mock_instance.get.call_args
 
         self.assertEqual('https://domain/api/v2/log-streams', args[0])
-        
+
     @mock.patch('auth0.v3.management.log_streams.RestClient')
     def test_get(self, mock_rc):
         mock_instance = mock_rc.return_value

--- a/auth0/v3/test/management/test_logs.py
+++ b/auth0/v3/test/management/test_logs.py
@@ -7,7 +7,7 @@ class TestLogs(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Logs(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_organizations.py
+++ b/auth0/v3/test/management/test_organizations.py
@@ -7,7 +7,7 @@ class TestOrganizations(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Organizations(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_resource_servers.py
+++ b/auth0/v3/test/management/test_resource_servers.py
@@ -7,7 +7,7 @@ class TestResourceServers(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = ResourceServers(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -151,7 +151,8 @@ class TestRest(unittest.TestCase):
 
     @mock.patch('requests.get')
     def test_get_rate_limit_error(self, mock_get):
-        rc = RestClient(jwt='a-token', telemetry=False)
+        rc = RestClient(jwt='a-token', telemetry=False, retries=0)
+        rc._skip_sleep = True
 
         mock_get.return_value.text = '{"statusCode": 429,' \
                                      ' "errorCode": "code",' \
@@ -172,15 +173,18 @@ class TestRest(unittest.TestCase):
         self.assertIsInstance(context.exception, RateLimitError)
         self.assertEqual(context.exception.reset_at, 9)
 
+        self.assertEqual(rc._metrics['retries'], 0)
+
     @mock.patch('requests.get')
     def test_get_rate_limit_error_without_headers(self, mock_get):
-        rc = RestClient(jwt='a-token', telemetry=False)
+        rc = RestClient(jwt='a-token', telemetry=False, retries=0)
+        rc._skip_sleep = True
 
         mock_get.return_value.text = '{"statusCode": 429,' \
                                      ' "errorCode": "code",' \
                                      ' "message": "message"}'
         mock_get.return_value.status_code = 429
-        
+
         mock_get.return_value.headers = {}
         with self.assertRaises(Auth0Error) as context:
             rc.get('the/url')
@@ -190,6 +194,175 @@ class TestRest(unittest.TestCase):
         self.assertEqual(context.exception.message, 'message')
         self.assertIsInstance(context.exception, RateLimitError)
         self.assertEqual(context.exception.reset_at, -1)
+
+        self.assertEqual(rc._metrics['retries'], 0)
+
+    @mock.patch('requests.get')
+    def test_get_rate_limit_custom_retries(self, mock_get):
+        rc = RestClient(jwt='a-token', telemetry=False, retries=5)
+        rc._skip_sleep = True
+
+        mock_get.return_value.text = '{"statusCode": 429,' \
+                                     ' "errorCode": "code",' \
+                                     ' "message": "message"}'
+        mock_get.return_value.status_code = 429
+        mock_get.return_value.headers = {
+            'x-ratelimit-limit': '3',
+            'x-ratelimit-remaining': '6',
+            'x-ratelimit-reset': '9',
+        }
+
+        with self.assertRaises(Auth0Error) as context:
+            response = rc.get('the/url')
+
+        self.assertEqual(context.exception.status_code, 429)
+        self.assertEqual(context.exception.error_code, 'code')
+        self.assertEqual(context.exception.message, 'message')
+        self.assertIsInstance(context.exception, RateLimitError)
+        self.assertEqual(context.exception.reset_at, 9)
+
+        self.assertEqual(rc._metrics['retries'], 5)
+        self.assertEqual(rc._metrics['retries'], len(rc._metrics['backoff']))
+
+    @mock.patch('requests.get')
+    def test_get_rate_limit_invalid_retries_below_min(self, mock_get):
+        rc = RestClient(jwt='a-token', telemetry=False, retries=-1)
+        rc._skip_sleep = True
+
+        mock_get.return_value.text = '{"statusCode": 429,' \
+                                     ' "errorCode": "code",' \
+                                     ' "message": "message"}'
+        mock_get.return_value.status_code = 429
+        mock_get.return_value.headers = {
+            'x-ratelimit-limit': '3',
+            'x-ratelimit-remaining': '6',
+            'x-ratelimit-reset': '9',
+        }
+
+        with self.assertRaises(Auth0Error) as context:
+            response = rc.get('the/url')
+
+        self.assertEqual(context.exception.status_code, 429)
+        self.assertEqual(context.exception.error_code, 'code')
+        self.assertEqual(context.exception.message, 'message')
+        self.assertIsInstance(context.exception, RateLimitError)
+        self.assertEqual(context.exception.reset_at, 9)
+
+        self.assertEqual(rc._metrics['retries'], 0)
+
+
+    @mock.patch('requests.get')
+    def test_get_rate_limit_invalid_retries_above_max(self, mock_get):
+        rc = RestClient(jwt='a-token', telemetry=False, retries=11)
+        rc._skip_sleep = True
+
+        mock_get.return_value.text = '{"statusCode": 429,' \
+                                     ' "errorCode": "code",' \
+                                     ' "message": "message"}'
+        mock_get.return_value.status_code = 429
+        mock_get.return_value.headers = {
+            'x-ratelimit-limit': '3',
+            'x-ratelimit-remaining': '6',
+            'x-ratelimit-reset': '9',
+        }
+
+        with self.assertRaises(Auth0Error) as context:
+            response = rc.get('the/url')
+
+        self.assertEqual(context.exception.status_code, 429)
+        self.assertEqual(context.exception.error_code, 'code')
+        self.assertEqual(context.exception.message, 'message')
+        self.assertIsInstance(context.exception, RateLimitError)
+        self.assertEqual(context.exception.reset_at, 9)
+
+        self.assertEqual(rc._metrics['retries'], rc.MAX_REQUEST_RETRIES())
+
+    @mock.patch('requests.get')
+    def test_get_rate_limit_retries_use_exponential_backoff(self, mock_get):
+        rc = RestClient(jwt='a-token', telemetry=False, retries=10)
+        rc._skip_sleep = True
+
+        mock_get.return_value.text = '{"statusCode": 429,' \
+                                     ' "errorCode": "code",' \
+                                     ' "message": "message"}'
+        mock_get.return_value.status_code = 429
+        mock_get.return_value.headers = {
+            'x-ratelimit-limit': '3',
+            'x-ratelimit-remaining': '6',
+            'x-ratelimit-reset': '9',
+        }
+
+        with self.assertRaises(Auth0Error) as context:
+            response = rc.get('the/url')
+
+        self.assertEqual(context.exception.status_code, 429)
+        self.assertEqual(context.exception.error_code, 'code')
+        self.assertEqual(context.exception.message, 'message')
+        self.assertIsInstance(context.exception, RateLimitError)
+        self.assertEqual(context.exception.reset_at, 9)
+
+        self.assertEqual(rc._metrics['retries'], 10)
+        self.assertEqual(rc._metrics['retries'], len(rc._metrics['backoff']))
+
+        baseBackoff = [0]
+        baseBackoffSum = 0
+        finalBackoff = 0
+
+        for i in range(0, 9):
+            backoff = 100 * 2 ** i
+            baseBackoff.append(backoff)
+            baseBackoffSum += backoff
+
+        for backoff in rc._metrics['backoff']:
+            finalBackoff += backoff
+
+        # Assert that exponential backoff is happening.
+        self.assertGreaterEqual(rc._metrics['backoff'][1], rc._metrics['backoff'][0])
+        self.assertGreaterEqual(rc._metrics['backoff'][2], rc._metrics['backoff'][1])
+        self.assertGreaterEqual(rc._metrics['backoff'][3], rc._metrics['backoff'][2])
+        self.assertGreaterEqual(rc._metrics['backoff'][4], rc._metrics['backoff'][3])
+        self.assertGreaterEqual(rc._metrics['backoff'][5], rc._metrics['backoff'][4])
+        self.assertGreaterEqual(rc._metrics['backoff'][6], rc._metrics['backoff'][5])
+        self.assertGreaterEqual(rc._metrics['backoff'][7], rc._metrics['backoff'][6])
+        self.assertGreaterEqual(rc._metrics['backoff'][8], rc._metrics['backoff'][7])
+        self.assertGreaterEqual(rc._metrics['backoff'][9], rc._metrics['backoff'][8])
+
+        # Ensure jitter is being applied.
+        self.assertNotEquals(rc._metrics['backoff'][1], baseBackoff[1])
+        self.assertNotEquals(rc._metrics['backoff'][2], baseBackoff[2])
+        self.assertNotEquals(rc._metrics['backoff'][3], baseBackoff[3])
+        self.assertNotEquals(rc._metrics['backoff'][4], baseBackoff[4])
+        self.assertNotEquals(rc._metrics['backoff'][5], baseBackoff[5])
+        self.assertNotEquals(rc._metrics['backoff'][6], baseBackoff[6])
+        self.assertNotEquals(rc._metrics['backoff'][7], baseBackoff[7])
+        self.assertNotEquals(rc._metrics['backoff'][8], baseBackoff[8])
+        self.assertNotEquals(rc._metrics['backoff'][9], baseBackoff[9])
+
+        # Ensure subsequent delay is never less than the minimum.
+        self.assertGreaterEqual(rc._metrics['backoff'][1], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][2], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][3], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][4], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][5], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][6], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][7], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][8], rc.MIN_REQUEST_RETRY_DELAY())
+        self.assertGreaterEqual(rc._metrics['backoff'][9], rc.MIN_REQUEST_RETRY_DELAY())
+
+        # Ensure delay is never more than the maximum.
+        self.assertLessEqual(rc._metrics['backoff'][0], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][1], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][2], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][3], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][4], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][5], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][6], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][7], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][8], rc.MAX_REQUEST_RETRY_DELAY())
+        self.assertLessEqual(rc._metrics['backoff'][9], rc.MAX_REQUEST_RETRY_DELAY())
+
+        # Ensure total delay sum is never more than 10s.
+        self.assertLessEqual(finalBackoff, 10000)
 
     @mock.patch('requests.post')
     def test_post(self, mock_post):

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -177,8 +177,7 @@ class TestRest(unittest.TestCase):
 
     @mock.patch('requests.get')
     def test_get_rate_limit_error_without_headers(self, mock_get):
-        rc = RestClient(jwt='a-token', telemetry=False, retries=0)
-        rc._skip_sleep = True
+        rc = RestClient(jwt='a-token', telemetry=False, retries=1)
 
         mock_get.return_value.text = '{"statusCode": 429,' \
                                      ' "errorCode": "code",' \
@@ -195,7 +194,7 @@ class TestRest(unittest.TestCase):
         self.assertIsInstance(context.exception, RateLimitError)
         self.assertEqual(context.exception.reset_at, -1)
 
-        self.assertEqual(rc._metrics['retries'], 0)
+        self.assertEqual(rc._metrics['retries'], 1)
 
     @mock.patch('requests.get')
     def test_get_rate_limit_custom_retries(self, mock_get):

--- a/auth0/v3/test/management/test_roles.py
+++ b/auth0/v3/test/management/test_roles.py
@@ -7,7 +7,7 @@ class TestRoles(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Roles(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_rules.py
+++ b/auth0/v3/test/management/test_rules.py
@@ -7,7 +7,7 @@ class TestRules(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Rules(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_rules_configs.py
+++ b/auth0/v3/test/management/test_rules_configs.py
@@ -7,7 +7,7 @@ class TestRulesConfigs(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = RulesConfigs(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_stats.py
+++ b/auth0/v3/test/management/test_stats.py
@@ -7,7 +7,7 @@ class TestStats(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Stats(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_tenants.py
+++ b/auth0/v3/test/management/test_tenants.py
@@ -7,7 +7,7 @@ class TestTenants(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Tenants(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_tickets.py
+++ b/auth0/v3/test/management/test_tickets.py
@@ -7,7 +7,7 @@ class TestTickets(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Tickets(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_user_blocks.py
+++ b/auth0/v3/test/management/test_user_blocks.py
@@ -7,7 +7,7 @@ class TestUserBlocks(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = UserBlocks(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_users.py
+++ b/auth0/v3/test/management/test_users.py
@@ -7,7 +7,7 @@ class TestUsers(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = Users(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 

--- a/auth0/v3/test/management/test_users_by_email.py
+++ b/auth0/v3/test/management/test_users_by_email.py
@@ -7,7 +7,7 @@ class TestUsersByEmail(unittest.TestCase):
 
     def test_init_with_optionals(self):
         t = UsersByEmail(domain='domain', token='jwttoken', telemetry=False, timeout=(10, 2))
-        self.assertEqual(t.client.timeout, (10, 2))
+        self.assertEqual(t.client.options.timeout, (10, 2))
         telemetry_header = t.client.base_headers.get('Auth0-Client', None)
         self.assertEqual(telemetry_header, None)
 


### PR DESCRIPTION
### Changes

This PR enables support for automatic retry of API requests that encounter a 429 rate-limit status response from the Auth0 API. It will retry, by default, up to 3 times, with a hard-coded cap of 10. It exponentially increases the delay between each request ("exponential backoff"), and uses a jitter technique to slightly randomize the variance of this delay.

- Adds a `RestClientOptions` object to carry a configuration throughout the Management calls of the SDK, from `Auth0` instantiation down through to the `RestClient` calls. There was no existing way of gracefully applying `RestClient` options (`telemetry`, `timeouts`, and now `retries`) without having to write custom instantiation code. This can now all be done just from the `Auth0` constructor.

Note: `RestClientOptions` is implemented in such a way as to provide this new cleaner configuration model without introducing breaking changes. All existing configuration arguments are still supported. If a `RestClientOptions` is not provided to `RestClient` during instantiation, one is created dynamically using any provided timeout or telemetry options passed as arguments. We should deprecate using the argument configurations in the future and transition developers toward using `RestClientOptions` directly.

- Updates `Auth0` constructor to accept `rest_options` argument for a `RestClientOptions` configuration object. This is further passed on to the constructors for all the Management endpoint classes.
- Updates `Blacklists`, `ClientGrants`, `Clients`, `Connections`, `CustomDomains`, `DeviceCredentials`, `EmailTemplates`, `Emails`, `Grants`, `Guardian`, `Hooks`, `Jobs`, `LogStreams`, `Logs`, `Organizations`, `ResourceServers`, `Roles`, `RulesConfigs`, `Rules`, `Stats`, `Tenants`, `Tickets`, `UserBlocks`, `UsersByEmail`, and `Users` constructors to accept `rest_options` argument for a `RestClientOptions` configuration object. 
- Updates `RestClient` constructor to accept `options` argument for a `RestClientOptions` configuration object.
- Updates `RestClient.get()` with automatic retry logic.
- Adds `RestClient.MAX_REQUEST_RETRIES()`, `MAX_REQUEST_RETRY_JITTER()`, `MAX_REQUEST_RETRY_DELAY()` and `MIN_REQUEST_RETRY_DELAY()` getters to read the hard limits from, to avoid using mutable values.
- Adds `RestClient._metrics` to aid in unit testing this new logic. This dict keeps track of the number of retry attempts, and the individual backoff windows applied to each retry.
- Adds `RestClient._skip_sleep` to avoid actually calling sleep() during unit tests and greatly slowing down the test process.
- Updates `test_get_rate_limit_error` and `test_get_rate_limit_error_without_headers`, and adds `test_get_rate_limit_custom_retries`, `test_get_rate_limit_invalid_retries_below_min`, `test_get_rate_limit_invalid_retries_above_max` and `test_get_rate_limit_retries_use_exponential_backoff` to unit tests to cover new functionality.
- Updates other tests to prefer reading from the new internal configuration model (although technically they would work without changes until the old model is deprecated.)

### References

Please see the internal SDK-2653 epic on this topic.

### Testing

Tests can be executed using `python3 -m unittest -v`.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
