### PR TITLE
Make the CI fail when the docs syntax is invalid

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,9 @@ jobs:
             - ".venv"
             - "/usr/local/bin"
             - "/usr/local/lib/python2.7/site-packages"
-      - run: coverage run --include=auth0/v3/*.py --omit=auth0/v3/test/*.py -m unittest discover
+      - run:
+          name: Run tests
+          command: coverage run --include=auth0/v3/*.py --omit=auth0/v3/test/*.py -m unittest discover
       - run:
           when: on_success
           command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,19 @@ jobs:
           command: |
             pip install .[test]
             pip install codecov
+            pip install -r docs/requirements.txt
       - save_cache:
           key: deps3-{{ .Branch }}-{{ checksum "setup.py" }}
           paths:
             - ".venv"
             - "/usr/local/bin"
             - "/usr/local/lib/python3.6/site-packages"
-      - run: coverage run --include=auth0/v3/*.py --omit=auth0/v3/test/*.py -m unittest discover
+      - run:
+          name: Run tests
+          command: coverage run --include=auth0/v3/*.py --omit=auth0/v3/test/*.py -m unittest discover
+      - run:
+          name: Build docs
+          command: cd docs/ && make html
       - run:
           when: on_success
           command: bash <(curl -s https://codecov.io/bash)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going -n -a
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,4 +87,4 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []

--- a/docs/source/v3.management.rst
+++ b/docs/source/v3.management.rst
@@ -122,7 +122,7 @@ management.logs module
    :show-inheritance:
 
 management.organizations module
--------------------------
+----------------------------------
 
 .. automodule:: auth0.v3.management.organizations
    :members:


### PR DESCRIPTION
### Changes

Adds a step to build the docs in the CI, failing if something if the syntax is wrong. This will help enforce good docs, now that we publish them to Readthedocs.

### References

List of options: https://www.sphinx-doc.org/en/master/man/sphinx-build.html

- `-W` converts warnings to errors
- `--keep-going` will not stop in the first error, useful to get the complete list of errors.
- `-n` will verify broken links and references
- `-a` runs the docs generation task even when the source code hasn't changed

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
