### PR TITLE
Add circuit breaker on Auth0 API calls

### DIFF
--- a/auth0/v3/authentication/base.py
+++ b/auth0/v3/authentication/base.py
@@ -3,6 +3,7 @@ import json
 import sys
 import platform
 import requests
+from circuitbreaker import circuit
 from ..exceptions import Auth0Error, RateLimitError
 
 UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
@@ -43,12 +44,14 @@ class AuthenticationBase(object):
                 'Auth0-Client': base64.b64encode(auth0_client),
             })
 
+    @circuit
     def post(self, url, data=None, headers=None):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
         response = requests.post(url=url, json=data, headers=request_headers, timeout=self.timeout)
         return self._process_response(response)
 
+    @circuit
     def get(self, url, params=None, headers=None):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -113,6 +113,7 @@ class RestClient(object):
     def MIN_REQUEST_RETRY_DELAY(self):
         return 100
 
+    @circuit
     def get(self, url, params=None):
         headers = self.base_headers.copy()
 
@@ -162,12 +163,14 @@ class RestClient(object):
         # Return the final Response
         return self._process_response(response)
 
+    @circuit
     def post(self, url, data=None):
         headers = self.base_headers.copy()
 
         response = requests.post(url, json=data, headers=headers, timeout=self.options.timeout)
         return self._process_response(response)
 
+    @circuit
     def file_post(self, url, data=None, files=None):
         headers = self.base_headers.copy()
         headers.pop('Content-Type', None)
@@ -175,18 +178,21 @@ class RestClient(object):
         response = requests.post(url, data=data, files=files, headers=headers, timeout=self.options.timeout)
         return self._process_response(response)
 
+    @circuit
     def patch(self, url, data=None):
         headers = self.base_headers.copy()
 
         response = requests.patch(url, json=data, headers=headers, timeout=self.options.timeout)
         return self._process_response(response)
 
+    @circuit
     def put(self, url, data=None):
         headers = self.base_headers.copy()
 
         response = requests.put(url, json=data, headers=headers, timeout=self.options.timeout)
         return self._process_response(response)
 
+    @circuit
     def delete(self, url, params=None, data=None):
         headers = self.base_headers.copy()
 

--- a/auth0/v3/management/rest.py
+++ b/auth0/v3/management/rest.py
@@ -7,6 +7,7 @@ import requests
 from ..exceptions import Auth0Error, RateLimitError
 from time import sleep
 from random import randint
+from circuitbreaker import circuit
 
 UNKNOWN_ERROR = 'a0.sdk.internal.unknown'
 

--- a/auth0/v3/test/authentication/test_base.py
+++ b/auth0/v3/test/authentication/test_base.py
@@ -12,6 +12,15 @@ from ...exceptions import Auth0Error, RateLimitError
 
 class TestBase(unittest.TestCase):
 
+    @mock.patch('requests.get')
+    @mock.patch('requests.post')
+    def setUp(self, mock_post, mock_set):
+        ab = AuthenticationBase('auth0.com')
+
+        # reset the circuit breaker
+        ab.get("the-url")
+        ab.post("the-url")
+
     def test_telemetry_enabled_by_default(self):
         ab = AuthenticationBase('auth0.com')
 

--- a/auth0/v3/test/management/test_rest.py
+++ b/auth0/v3/test/management/test_rest.py
@@ -11,6 +11,22 @@ from ...exceptions import Auth0Error, RateLimitError
 
 
 class TestRest(unittest.TestCase):
+
+    @mock.patch('requests.get')
+    @mock.patch('requests.post')
+    @mock.patch('requests.put')
+    @mock.patch('requests.patch')
+    @mock.patch('requests.delete')
+    def setUp(self, mock_delete, mock_patch, mock_put, mock_post, mock_set):
+        rc = RestClient(jwt='a-token', telemetry=False, timeout=(10, 2))
+
+        # reset the circuit breaker
+        rc.get("the-url")
+        rc.post("the-url")
+        rc.put("the-url")
+        rc.patch("the-url")
+        rc.delete("the-url")
+
     def test_options_are_used_and_override(self):
         """
         This test ensures RestClientOptions are read when passed to

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+circuitbreaker==1.3.2
 sphinx==4.1.2
 sphinx-rtd-theme==0.5.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-circuitbreaker==1.3.2
 sphinx==4.1.2
 sphinx-rtd-theme==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author_email='support@auth0.com',
     license='MIT',
     packages=find_packages(),
-    install_requires=['requests>=2.14.0', 'pyjwt[crypto]>=1.7.1'],
+    install_requires=['requests>=2.14.0', 'pyjwt[crypto]>=1.7.1', 'circuitbreaker>=1.3.2'],
     extras_require={'test': ['mock>=1.3.0', 'pre-commit']},
     python_requires='>=2.7, !=3.0.*, !=3.1.*',
     classifiers=[


### PR DESCRIPTION
### Changes

If a service is using Auth0 as a 3rd party dependencies, there can be cases that all Auth0 API calls fail because 

* A wrongful (e.g. client) credential is used.
* There's some network problem between the service and Auth0, so the later one is not reachable.

When that happens, there can be potentially a lot of pending API calls, and they'll all timeout after a period defined in https://github.com/auth0/auth0-python/blob/0f82f78e825cbd49957651cdead8b7f853f4af59/auth0/v3/authentication/base.py#L23 and https://github.com/auth0/auth0-python/blob/f6925b655bc0d299c7d7f6355b02ebb617fe605a/auth0/v3/management/rest.py#L32 Without a properly defined threading model, all these waits may make the service run out of resources.

After this change adopting the [circuit breaker pattern](https://martinfowler.com/bliki/CircuitBreaker.html), after a certain time of failures, the followup API calls will be short. 

Alternative designs or approaches:

* It is possible to customize the exception type and failure threshold by [this particular chosen library](https://github.com/fabfuel/circuitbreaker#configuration).
* There are [other circuit breaking libraries](https://pypi.org/search/?q=circuit+breaker) in python we can potentially use to implement this.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
