### PR TITLE
[SDK-3179] Add /api/v2/branding endpoints support

### DIFF
--- a/auth0/v3/management/branding.py
+++ b/auth0/v3/management/branding.py
@@ -89,4 +89,8 @@ class Branding(object):
         See: https://auth0.com/docs/api/management/v2#!/Branding/put_universal_login
         """
 
-        return self.client.put(self._url("templates", "universal-login"), type="put_universal-login_body", body={"template":body})
+        return self.client.put(
+            self._url("templates", "universal-login"),
+            type="put_universal-login_body",
+            body={"template": body},
+        )

--- a/auth0/v3/management/branding.py
+++ b/auth0/v3/management/branding.py
@@ -1,0 +1,92 @@
+from .rest import RestClient
+
+
+class Branding(object):
+    """Auth0 Branding endpoints
+
+    Args:
+        domain (str): Your Auth0 domain, e.g: 'username.auth0.com'
+
+        token (str): Management API v2 Token
+
+        telemetry (bool, optional): Enable or disable Telemetry
+            (defaults to True)
+
+        timeout (float or tuple, optional): Change the requests
+            connect and read timeout. Pass a tuple to specify
+            both values separately or a float to set both to it.
+            (defaults to 5.0 for both)
+
+        rest_options (RestClientOptions): Pass an instance of
+            RestClientOptions to configure additional RestClient
+            options, such as rate-limit retries.
+            (defaults to None)
+    """
+
+    def __init__(
+        self,
+        domain,
+        token,
+        telemetry=True,
+        timeout=5.0,
+        protocol="https",
+        rest_options=None,
+    ):
+        self.domain = domain
+        self.protocol = protocol
+        self.client = RestClient(
+            jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options
+        )
+
+    def _url(self, *args):
+        url = "{}://{}/api/v2/branding".format(self.protocol, self.domain)
+        for p in args:
+            if p is not None:
+                url = "{}/{}".format(url, p)
+        return url
+
+    def get(self, aud=None):
+        """Retrieve branding settings. Requires "read:branding" scope.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/get_branding
+        """
+
+        return self.client.get(self._url())
+
+    def update(self, body):
+        """Update branding settings. Requires "update:branding" scope.
+
+        Args:
+            body (dict): Attributes for the updated trigger binding.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/patch_branding
+        """
+
+        return self.client.patch(self._url(), data=body)
+
+    def get_template_universal_login(self):
+        """Get template for New Universal Login Experience. Requires "read:branding" scope.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/get_universal_login
+        """
+
+        return self.client.get(self._url("templates", "universal-login"))
+
+    def delete_template_universal_login(self):
+        """Delete template for New Universal Login Experience. Requires "delete:branding" scope.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/delete_universal_login
+        """
+
+        return self.client.delete(self._url("templates", "universal-login"))
+
+    def update_template_universal_login(self, body):
+        """Update template for New Universal Login Experience. Requires "update:branding" scope.
+
+        Args:
+            body (str): Complete HTML content to assign to the template. See linked API documentation for example.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/put_universal_login
+        """
+
+        return self.client.put(self._url("templates", "universal-login"), type="put_universal-login_body", body={"template":body})

--- a/auth0/v3/test/management/test_branding.py
+++ b/auth0/v3/test/management/test_branding.py
@@ -1,0 +1,73 @@
+import unittest
+import mock
+from ...management.branding import Branding
+
+
+class TestBranding(unittest.TestCase):
+    def test_init_with_optionals(self):
+        branding = Branding(
+            domain="domain", token="jwttoken", telemetry=False, timeout=(10, 2)
+        )
+        self.assertEqual(branding.client.options.timeout, (10, 2))
+
+        telemetry = branding.client.base_headers.get("Auth0-Client", None)
+        self.assertEqual(telemetry, None)
+
+    @mock.patch("auth0.v3.management.branding.RestClient")
+    def test_get(self, mock_rc):
+        api = mock_rc.return_value
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.get()
+
+        api.get.assert_called_with(
+            "https://domain/api/v2/branding",
+        )
+
+    @mock.patch("auth0.v3.management.branding.RestClient")
+    def test_update(self, mock_rc):
+        api = mock_rc.return_value
+        api.patch.return_value = {}
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.update({"a": "b", "c": "d"})
+
+        api.patch.assert_called_with(
+            "https://domain/api/v2/branding", data={"a": "b", "c": "d"}
+        )
+
+    @mock.patch("auth0.v3.management.branding.RestClient")
+    def test_get_template_universal_login(self, mock_rc):
+        api = mock_rc.return_value
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.get_template_universal_login()
+
+        api.get.assert_called_with(
+            "https://domain/api/v2/branding/templates/universal-login",
+        )
+
+    @mock.patch("auth0.v3.management.branding.RestClient")
+    def test_delete_template_universal_login(self, mock_rc):
+        api = mock_rc.return_value
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.delete_template_universal_login()
+
+        api.delete.assert_called_with(
+            "https://domain/api/v2/branding/templates/universal-login",
+        )
+
+    @mock.patch("auth0.v3.management.branding.RestClient")
+    def test_update_template_universal_login(self, mock_rc):
+        api = mock_rc.return_value
+        api.put.return_value = {}
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.update_template_universal_login({"a": "b", "c": "d"})
+
+        api.put.assert_called_with(
+            "https://domain/api/v2/branding/templates/universal-login",
+            type="put_universal-login_body",
+            body={"template": {"a": "b", "c": "d"}},
+        )

--- a/auth0/v3/test/management/test_branding.py
+++ b/auth0/v3/test/management/test_branding.py
@@ -1,5 +1,7 @@
 import unittest
+
 import mock
+
 from ...management.branding import Branding
 
 


### PR DESCRIPTION
This PR adds `/api/v2/branding` endpoints support for the Management API. It expands our tests to cover the additional class and methods added for support.