### PR TITLE
Expose `mfa_token` in the `Auth0Error` class

### DIFF
--- a/auth0/v3/exceptions.py
+++ b/auth0/v3/exceptions.py
@@ -1,8 +1,9 @@
 class Auth0Error(Exception):
-    def __init__(self, status_code, error_code, message):
+    def __init__(self, status_code, error_code, message, content=None):
         self.status_code = status_code
         self.error_code = error_code
         self.message = message
+        self.content = content
 
     def __str__(self):
         return "{}: {}".format(self.status_code, self.message)


### PR DESCRIPTION
### Changes
This PR includes changes to add the `mfa_token` in the `Auth0Error` as required by this [issue](https://github.com/auth0/auth0-python/issues/315). This is a first pass at the logic, hopefully it helps!

### Testing
I've added an additional test (*test_post_error_mfa_required*) to `auth0/v3/test/authentication/test_base.py` which passes along with the existing unit tests.
```
platform darwin -- Python 3.8.9, pytest-7.1.0, pluggy-1.0.0
rootdir: /Users/nialdaly/open-source-projects/auth0/auth0-python
plugins: mock-3.7.0
collected 364 items                                                                                                                              

auth0/v3/test/authentication/test_authorize_client.py ..                                                                                   [  0%]
auth0/v3/test/authentication/test_base.py ..................                                                                               [  5%]
auth0/v3/test/authentication/test_database.py ...                                                                                          [  6%]
auth0/v3/test/authentication/test_delegated.py ...                                                                                         [  7%]
auth0/v3/test/authentication/test_enterprise.py ..                                                                                         [  7%]
auth0/v3/test/authentication/test_get_token.py .......                                                                                     [  9%]
auth0/v3/test/authentication/test_logout.py ..                                                                                             [ 10%]
auth0/v3/test/authentication/test_passwordless.py .......                                                                                  [ 12%]
auth0/v3/test/authentication/test_revoke_token.py .                                                                                        [ 12%]
auth0/v3/test/authentication/test_social.py ..                                                                                             [ 12%]
auth0/v3/test/authentication/test_token_verifier.py ........................................                                               [ 23%]
auth0/v3/test/authentication/test_users.py ..                                                                                              [ 24%]
auth0/v3/test/management/test_actions.py ..............                                                                                    [ 28%]
auth0/v3/test/management/test_atack_protection.py .......                                                                                  [ 30%]
auth0/v3/test/management/test_auth0.py ............................                                                                        [ 37%]
auth0/v3/test/management/test_blacklists.py ...                                                                                            [ 38%]
auth0/v3/test/management/test_branding.py ......                                                                                           [ 40%]
auth0/v3/test/management/test_client_grants.py .....                                                                                       [ 41%]
auth0/v3/test/management/test_clients.py .......                                                                                           [ 43%]
auth0/v3/test/management/test_connections.py .......                                                                                       [ 45%]
auth0/v3/test/management/test_custom_domains.py .....                                                                                      [ 46%]
auth0/v3/test/management/test_device_credentials.py ....                                                                                   [ 48%]
auth0/v3/test/management/test_email_endpoints.py ....                                                                                      [ 49%]
auth0/v3/test/management/test_emails.py .....                                                                                              [ 50%]
auth0/v3/test/management/test_grants.py ...                                                                                                [ 51%]
auth0/v3/test/management/test_guardian.py ..........                                                                                       [ 54%]
auth0/v3/test/management/test_hooks.py ..........                                                                                          [ 56%]
auth0/v3/test/management/test_jobs.py .......                                                                                              [ 58%]
auth0/v3/test/management/test_log_streams.py ......                                                                                        [ 60%]
auth0/v3/test/management/test_logs.py ...                                                                                                  [ 61%]
auth0/v3/test/management/test_organizations.py ......................                                                                      [ 67%]
auth0/v3/test/management/test_prompts.py .....                                                                                             [ 68%]
auth0/v3/test/management/test_resource_servers.py ......                                                                                   [ 70%]
auth0/v3/test/management/test_rest.py ........................................                                                             [ 81%]
auth0/v3/test/management/test_roles.py ...........                                                                                         [ 84%]
auth0/v3/test/management/test_rules.py ......                                                                                              [ 85%]
auth0/v3/test/management/test_rules_configs.py ....                                                                                        [ 87%]
auth0/v3/test/management/test_stats.py ...                                                                                                 [ 87%]
auth0/v3/test/management/test_tenants.py ...                                                                                               [ 88%]
auth0/v3/test/management/test_tickets.py ...                                                                                               [ 89%]
auth0/v3/test/management/test_user_blocks.py .....                                                                                         [ 90%]
auth0/v3/test/management/test_users.py ......................                                                                              [ 96%]
auth0/v3/test/management/test_users_by_email.py ..                                                                                         [ 97%]
auth0/v3/test_async/test_asyncify.py .........                                                                                             [100%]

================================================================ warnings summary ================================================================
auth0/v3/test/authentication/test_database.py::TestDatabase::test_login
  /Users/nialdaly/open-source-projects/auth0/auth0-python/auth0/v3/authentication/database.py:32: DeprecationWarning: /oauth/ro will be deprecated in future releases
    warnings.warn(

auth0/v3/test/authentication/test_passwordless.py::TestPasswordless::test_send_sms_login
auth0/v3/test/authentication/test_passwordless.py::TestPasswordless::test_send_sms_login_with_scope
  /Users/nialdaly/open-source-projects/auth0/auth0-python/auth0/v3/authentication/passwordless.py:100: DeprecationWarning: /oauth/ro will be deprecated in future releases
    warnings.warn(

auth0/v3/test/authentication/test_users.py::TestUsers::test_tokeninfo
  /Users/nialdaly/open-source-projects/auth0/auth0-python/auth0/v3/authentication/users.py:45: DeprecationWarning: /tokeninfo will be deprecated in future releases
    warnings.warn(

auth0/v3/test/management/test_jobs.py::TestJobs::test_get_job_results
  /Users/nialdaly/open-source-projects/auth0/auth0-python/auth0/v3/management/jobs.py:82: DeprecationWarning: /jobs/{id}/results is no longer available. The get(id) function will be called instead.
    warnings.warn(

auth0/v3/test/management/test_users.py::TestUsers::test_delete_all_users
  /Users/nialdaly/open-source-projects/auth0/auth0-python/auth0/v3/management/users.py:125: DeprecationWarning: DELETE all users endpoint is no longer available.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 364 passed, 6 warnings in 2.81s =========================================================
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
