### PR TITLE
Bump ship/orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   python: circleci/python@2.0.3
-  ship: auth0/ship@dev:7cb543a
+  ship: auth0/ship@dev:989f2c5
 
 executors:
   python_3_10:


### PR DESCRIPTION
Using the last dev version before we release the orb as we have a chance to test it end-to-end.