### PR TITLE
[SDK-3465] Update Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   python: circleci/python@2.0.3
   ship: auth0/ship@0.5.0
+  codecov: codecov/codecov@3.1.1
 
 executors:
   python_3_10:
@@ -32,7 +33,7 @@ jobs:
           pkg-manager: pip-dist
           path-args: ".[test]"
       - run: coverage run -m unittest discover -s auth0/v3/test -t .
-      - run: bash <(curl -s https://codecov.io/bash)
+      - codecov/upload
 
 workflows:
   main:
@@ -51,4 +52,3 @@ workflows:
           requires:
             - python_3
             - python_2
-


### PR DESCRIPTION
### Changes

This PR replaces the Codecov bash uploader in your CircleCI configuration to use the now recommended Orb-based approach.

### References

See internal ticket SDK-3465

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
