### PR TITLE
Bugfix missing-import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -391,6 +391,7 @@ Management Endpoints
 - Actions() (``Auth0().actions``)
 - AttackProtection() (``Auth0().attack_protection``)
 - Blacklists() ( ``Auth0().blacklists`` )
+- Branding() ( ``Auth0().branding`` )
 - ClientGrants() ( ``Auth0().client_grants`` )
 - Clients() ( ``Auth0().clients`` )
 - Connections() ( ``Auth0().connections`` )

--- a/auth0/v3/management/__init__.py
+++ b/auth0/v3/management/__init__.py
@@ -26,12 +26,14 @@ from .tickets import Tickets
 from .user_blocks import UserBlocks
 from .users import Users
 from .users_by_email import UsersByEmail
+from .branding import Branding
 
 __all__ = (
     "Auth0",
     "Actions",
     "AttackProtection",
     "Blacklists",
+    "Branding",
     "ClientGrants",
     "Clients",
     "Connections",

--- a/auth0/v3/management/__init__.py
+++ b/auth0/v3/management/__init__.py
@@ -2,6 +2,7 @@ from .actions import Actions
 from .attack_protection import AttackProtection
 from .auth0 import Auth0
 from .blacklists import Blacklists
+from .branding import Branding
 from .client_grants import ClientGrants
 from .clients import Clients
 from .connections import Connections
@@ -26,7 +27,7 @@ from .tickets import Tickets
 from .user_blocks import UserBlocks
 from .users import Users
 from .users_by_email import UsersByEmail
-from .branding import Branding
+
 
 __all__ = (
     "Auth0",

--- a/auth0/v3/management/auth0.py
+++ b/auth0/v3/management/auth0.py
@@ -2,6 +2,7 @@ from ..utils import is_async_available
 from .actions import Actions
 from .attack_protection import AttackProtection
 from .blacklists import Blacklists
+from .branding import Branding
 from .client_grants import ClientGrants
 from .clients import Clients
 from .connections import Connections
@@ -28,10 +29,12 @@ from .user_blocks import UserBlocks
 from .users import Users
 from .users_by_email import UsersByEmail
 
+
 modules = {
     "actions": Actions,
     "attack_protection": AttackProtection,
     "blacklists": Blacklists,
+    "branding": Branding,
     "client_grants": ClientGrants,
     "clients": Clients,
     "connections": Connections,

--- a/docs/source/v3.management.rst
+++ b/docs/source/v3.management.rst
@@ -17,6 +17,14 @@ management.blacklists module
    :undoc-members:
    :show-inheritance:
 
+management.branding module
+-------------------------------
+
+.. automodule:: auth0.v3.management.branding
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 management.client\_grants module
 -----------------------------------
 


### PR DESCRIPTION
### Changes

Updated imports to include Branding

### References

Please include relevant links supporting this change such as a:

https://github.com/auth0/auth0-python/issues/414

### Testing

Build and attempt to access the Management branding endpoint:

Grab a management token and authenticate per the example docs:
```
from auth0.v3.authentication import GetToken
from auth0.v3.management import Auth0

domain = 'myaccount.auth0.com'
non_interactive_client_id = 'exampleid'
non_interactive_client_secret = 'examplesecret'

get_token = GetToken(domain)
token = get_token.client_credentials(non_interactive_client_id,
   non_interactive_client_secret, 'https://{}/api/v2/'.format(domain))
mgmt_api_token = token['access_token']

domain = 'myaccount.auth0.com'
mgmt_api_token = 'MGMT_API_TOKEN'

auth0 = Auth0(domain, mgmt_api_token)
```
Run: 
`auth0.branding.get()`

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
