### PR TITLE
Use the 'get' retry mechanic on other request methods

### DIFF
--- a/auth0/v3/rest.py
+++ b/auth0/v3/rest.py
@@ -166,46 +166,166 @@ class RestClient(object):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
 
-        response = requests.post(
-            url, json=data, headers=request_headers, timeout=self.options.timeout
-        )
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            # Issue the request
+            response = requests.post(
+                url, json=data, headers=request_headers, timeout=self.options.timeout
+            )
+
+            # If the response did not have a 429 header, or the attempt number is greater than the configured retries, break
+            if response.status_code != 429 or attempt > self._retries:
+                break
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                sleep(wait / 1000)
+
+        # Return the final Response
         return self._process_response(response)
 
     def file_post(self, url, data=None, files=None):
         headers = self.base_headers.copy()
         headers.pop("Content-Type", None)
 
-        response = requests.post(
-            url, data=data, files=files, headers=headers, timeout=self.options.timeout
-        )
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            # Issue the request
+            response = requests.post(
+                url, data=data, files=files, headers=headers, timeout=self.options.timeout
+            )
+
+            # If the response did not have a 429 header, or the attempt number is greater than the configured retries, break
+            if response.status_code != 429 or attempt > self._retries:
+                break
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                sleep(wait / 1000)
+
+        # Return the final Response
         return self._process_response(response)
 
     def patch(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.patch(
-            url, json=data, headers=headers, timeout=self.options.timeout
-        )
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            # Issue the request
+            response = requests.patch(
+                url, json=data, headers=headers, timeout=self.options.timeout
+            )
+
+            # If the response did not have a 429 header, or the attempt number is greater than the configured retries, break
+            if response.status_code != 429 or attempt > self._retries:
+                break
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                sleep(wait / 1000)
+
+        # Return the final Response
         return self._process_response(response)
 
     def put(self, url, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.put(
-            url, json=data, headers=headers, timeout=self.options.timeout
-        )
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            # Issue the request
+            response = requests.put(
+                url, json=data, headers=headers, timeout=self.options.timeout
+            )
+
+            # If the response did not have a 429 header, or the attempt number is greater than the configured retries, break
+            if response.status_code != 429 or attempt > self._retries:
+                break
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                sleep(wait / 1000)
+
+        # Return the final Response
         return self._process_response(response)
 
     def delete(self, url, params=None, data=None):
         headers = self.base_headers.copy()
 
-        response = requests.delete(
-            url,
-            headers=headers,
-            params=params or {},
-            json=data,
-            timeout=self.options.timeout,
-        )
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            # Issue the request
+            response = requests.delete(
+                url,
+                headers=headers,
+                params=params or {},
+                json=data,
+                timeout=self.options.timeout,
+            )
+
+            # If the response did not have a 429 header, or the attempt number is greater than the configured retries, break
+            if response.status_code != 429 or attempt > self._retries:
+                break
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                sleep(wait / 1000)
+
+        # Return the final Response
         return self._process_response(response)
 
     def _calculate_wait(self, attempt):

--- a/auth0/v3/rest_async.py
+++ b/auth0/v3/rest_async.py
@@ -95,23 +95,138 @@ class AsyncRestClient(RestClient):
     async def post(self, url, data=None, headers=None):
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
-        return await self._request("post", url, json=data, headers=request_headers)
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            try:
+                response = await self._request("post", url, json=data, headers=request_headers)
+                return response
+            except RateLimitError as e:
+                # If the attempt number is greater than the configured retries, raise RateLimitError
+                if attempt > self._retries:
+                    raise e
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                await asyncio.sleep(wait / 1000)
 
     async def file_post(self, url, data=None, files=None):
         headers = self.base_headers.copy()
         headers.pop("Content-Type", None)
-        return await self._request("post", url, data={**data, **files}, headers=headers)
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            try:
+                response = await self._request("post", url, data={**data, **files}, headers=headers)
+                return response
+            except RateLimitError as e:
+                # If the attempt number is greater than the configured retries, raise RateLimitError
+                if attempt > self._retries:
+                    raise e
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                await asyncio.sleep(wait / 1000)
 
     async def patch(self, url, data=None):
-        return await self._request("patch", url, json=data)
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            try:
+                response = await self._request("patch", url, json=data)
+                return response
+            except RateLimitError as e:
+                # If the attempt number is greater than the configured retries, raise RateLimitError
+                if attempt > self._retries:
+                    raise e
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                await asyncio.sleep(wait / 1000)
 
     async def put(self, url, data=None):
-        return await self._request("put", url, json=data)
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            try:
+                response = await self._request("put", url, json=data)
+                return response
+            except RateLimitError as e:
+                # If the attempt number is greater than the configured retries, raise RateLimitError
+                if attempt > self._retries:
+                    raise e
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                await asyncio.sleep(wait / 1000)
 
     async def delete(self, url, params=None, data=None):
-        return await self._request(
-            "delete", url, json=data, params=_clean_params(params) or {}
-        )
+        # Track the API request attempt number
+        attempt = 0
+
+        # Reset the metrics tracker
+        self._metrics = {"retries": 0, "backoff": []}
+
+        while True:
+            # Increment attempt number
+            attempt += 1
+
+            try:
+                response = await self._request(
+                    "delete", url, json=data, params=_clean_params(params) or {}
+                )
+                return response
+            except RateLimitError as e:
+                # If the attempt number is greater than the configured retries, raise RateLimitError
+                if attempt > self._retries:
+                    raise e
+
+            wait = self._calculate_wait(attempt)
+
+            # Skip calling sleep() when running unit tests
+            if self._skip_sleep is False:
+                # sleep() functions in seconds, so convert the milliseconds formula above accordingly
+                await asyncio.sleep(wait / 1000)
 
     async def _process_response(self, response):
         parsed_response = await self._parse(response)


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

Adds the retry mechanism used by the 'get' method to all the other request methods


### Testing

- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
