### PR TITLE
fix: Resolve Python3 tests failing with missing GitLab credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
     - id: flake8


### PR DESCRIPTION
### Changes

This PR fixes the Python3 test suite for the SDK, which has been failing during the `pre-commit run --all-files` step asking for GitLab authentication credentials. This was due to the `.pre-commit-config.yaml` file referencing the GitLab mirror for the project, as opposed to GitHub.

### References

Internal ticket SDK-3883

### Testing

This change fixes test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
