### PR TITLE
Remove unnecessary type param from update_template_universal_login

### DIFF
--- a/auth0/v3/management/branding.py
+++ b/auth0/v3/management/branding.py
@@ -91,6 +91,5 @@ class Branding(object):
 
         return self.client.put(
             self._url("templates", "universal-login"),
-            type="put_universal-login_body",
             body={"template": body},
         )

--- a/auth0/v3/test/management/test_branding.py
+++ b/auth0/v3/test/management/test_branding.py
@@ -70,6 +70,5 @@ class TestBranding(unittest.TestCase):
 
         api.put.assert_called_with(
             "https://domain/api/v2/branding/templates/universal-login",
-            type="put_universal-login_body",
             body={"template": {"a": "b", "c": "d"}},
         )


### PR DESCRIPTION
### Changes

The type argument is not required for `update_template_universal_login`

### References

fixes #452 
