### PR TITLE
Drop Python2 syntax

### DIFF
--- a/auth0/asyncify.py
+++ b/auth0/asyncify.py
@@ -31,10 +31,10 @@ def asyncify(cls):
         ):
             if token is None:
                 # Wrap the auth client
-                super(AsyncClient, self).__init__(domain, telemetry, timeout, protocol)
+                super().__init__(domain, telemetry, timeout, protocol)
             else:
                 # Wrap the mngtmt client
-                super(AsyncClient, self).__init__(
+                super().__init__(
                     domain, token, telemetry, timeout, protocol, rest_options
                 )
             self.client = AsyncRestClient(
@@ -53,10 +53,10 @@ def asyncify(cls):
         ):
             if token is None:
                 # Wrap the auth client
-                super(Wrapper, self).__init__(domain, telemetry, timeout, protocol)
+                super().__init__(domain, telemetry, timeout, protocol)
             else:
                 # Wrap the mngtmt client
-                super(Wrapper, self).__init__(
+                super().__init__(
                     domain, token, telemetry, timeout, protocol, rest_options
                 )
 

--- a/auth0/authentication/async_token_verifier.py
+++ b/auth0/authentication/async_token_verifier.py
@@ -13,7 +13,7 @@ class AsyncAsymmetricSignatureVerifier(AsymmetricSignatureVerifier):
     """
 
     def __init__(self, jwks_url, algorithm="RS256"):
-        super(AsyncAsymmetricSignatureVerifier, self).__init__(jwks_url, algorithm)
+        super().__init__(jwks_url, algorithm)
         self._fetcher = AsyncJwksFetcher(jwks_url)
 
     def set_session(self, session):
@@ -58,7 +58,7 @@ class AsyncJwksFetcher(JwksFetcher):
     """
 
     def __init__(self, *args, **kwargs):
-        super(AsyncJwksFetcher, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._async_client = AsyncRestClient(None)
 
     def set_session(self, session):

--- a/auth0/authentication/base.py
+++ b/auth0/authentication/base.py
@@ -5,7 +5,7 @@ from .client_authentication import add_client_authentication
 UNKNOWN_ERROR = "a0.sdk.internal.unknown"
 
 
-class AuthenticationBase(object):
+class AuthenticationBase:
     """Base authentication object providing simple REST methods.
 
     Args:

--- a/auth0/authentication/token_verifier.py
+++ b/auth0/authentication/token_verifier.py
@@ -8,7 +8,7 @@ import requests
 from auth0.exceptions import TokenValidationError
 
 
-class SignatureVerifier(object):
+class SignatureVerifier:
     """Abstract class that will verify a given JSON web token's signature
     using the key fetched internally given its key id.
 
@@ -119,7 +119,7 @@ class SymmetricSignatureVerifier(SignatureVerifier):
     """
 
     def __init__(self, shared_secret, algorithm="HS256"):
-        super(SymmetricSignatureVerifier, self).__init__(algorithm)
+        super().__init__(algorithm)
         self._shared_secret = shared_secret
 
     def _fetch_key(self, key_id=None):
@@ -135,14 +135,14 @@ class AsymmetricSignatureVerifier(SignatureVerifier):
     """
 
     def __init__(self, jwks_url, algorithm="RS256"):
-        super(AsymmetricSignatureVerifier, self).__init__(algorithm)
+        super().__init__(algorithm)
         self._fetcher = JwksFetcher(jwks_url)
 
     def _fetch_key(self, key_id=None):
         return self._fetcher.get_key(key_id)
 
 
-class JwksFetcher(object):
+class JwksFetcher:
     """Class that fetches and holds a JSON web key set.
     This class makes use of an in-memory cache. For it to work properly, define this instance once and re-use it.
 

--- a/auth0/authentication/users.py
+++ b/auth0/authentication/users.py
@@ -1,7 +1,7 @@
 from auth0.rest import RestClient, RestClientOptions
 
 
-class Users(object):
+class Users:
     """Users client.
 
     Args:

--- a/auth0/exceptions.py
+++ b/auth0/exceptions.py
@@ -11,9 +11,7 @@ class Auth0Error(Exception):
 
 class RateLimitError(Auth0Error):
     def __init__(self, error_code, message, reset_at):
-        super().__init__(
-            status_code=429, error_code=error_code, message=message
-        )
+        super().__init__(status_code=429, error_code=error_code, message=message)
         self.reset_at = reset_at
 
 

--- a/auth0/exceptions.py
+++ b/auth0/exceptions.py
@@ -11,7 +11,7 @@ class Auth0Error(Exception):
 
 class RateLimitError(Auth0Error):
     def __init__(self, error_code, message, reset_at):
-        super(RateLimitError, self).__init__(
+        super().__init__(
             status_code=429, error_code=error_code, message=message
         )
         self.reset_at = reset_at

--- a/auth0/management/actions.py
+++ b/auth0/management/actions.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Actions(object):
+class Actions:
     """Auth0 Actions endpoints
 
     Args:

--- a/auth0/management/async_auth0.py
+++ b/auth0/management/async_auth0.py
@@ -4,7 +4,7 @@ from ..asyncify import asyncify
 from .auth0 import modules
 
 
-class AsyncAuth0(object):
+class AsyncAuth0:
     """Provides easy access to all endpoint classes
 
     Args:

--- a/auth0/management/attack_protection.py
+++ b/auth0/management/attack_protection.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class AttackProtection(object):
+class AttackProtection:
     """Auth0 attack protection endpoints
 
     Args:

--- a/auth0/management/auth0.py
+++ b/auth0/management/auth0.py
@@ -64,7 +64,7 @@ modules = {
 }
 
 
-class Auth0(object):
+class Auth0:
     """Provides easy access to all endpoint classes
 
     Args:

--- a/auth0/management/blacklists.py
+++ b/auth0/management/blacklists.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Blacklists(object):
+class Blacklists:
     """Auth0 blacklists endpoints
 
     Args:

--- a/auth0/management/branding.py
+++ b/auth0/management/branding.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Branding(object):
+class Branding:
     """Auth0 Branding endpoints
 
     Args:

--- a/auth0/management/client_credentials.py
+++ b/auth0/management/client_credentials.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class ClientCredentials(object):
+class ClientCredentials:
     """Auth0 client credentials endpoints.
 
     Args:

--- a/auth0/management/client_grants.py
+++ b/auth0/management/client_grants.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class ClientGrants(object):
+class ClientGrants:
     """Auth0 client grants endpoints
 
     Args:

--- a/auth0/management/clients.py
+++ b/auth0/management/clients.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Clients(object):
+class Clients:
     """Auth0 applications endpoints
 
     Args:

--- a/auth0/management/connections.py
+++ b/auth0/management/connections.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Connections(object):
+class Connections:
     """Auth0 connection endpoints
 
     Args:

--- a/auth0/management/custom_domains.py
+++ b/auth0/management/custom_domains.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class CustomDomains(object):
+class CustomDomains:
     """Auth0 custom domains endpoints
 
     Args:

--- a/auth0/management/device_credentials.py
+++ b/auth0/management/device_credentials.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class DeviceCredentials(object):
+class DeviceCredentials:
     """Auth0 connection endpoints
 
     Args:

--- a/auth0/management/email_templates.py
+++ b/auth0/management/email_templates.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class EmailTemplates(object):
+class EmailTemplates:
     """Auth0 email templates endpoints
 
     Args:

--- a/auth0/management/emails.py
+++ b/auth0/management/emails.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Emails(object):
+class Emails:
     """Auth0 email endpoints
 
     Args:

--- a/auth0/management/grants.py
+++ b/auth0/management/grants.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Grants(object):
+class Grants:
     """Auth0 grants endpoints
 
     Args:

--- a/auth0/management/guardian.py
+++ b/auth0/management/guardian.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Guardian(object):
+class Guardian:
     """Auth0 guardian endpoints
 
     Args:

--- a/auth0/management/hooks.py
+++ b/auth0/management/hooks.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Hooks(object):
+class Hooks:
 
     """Hooks endpoint implementation.
 

--- a/auth0/management/jobs.py
+++ b/auth0/management/jobs.py
@@ -3,7 +3,7 @@ import warnings
 from ..rest import RestClient
 
 
-class Jobs(object):
+class Jobs:
     """Auth0 jobs endpoints
 
     Args:

--- a/auth0/management/log_streams.py
+++ b/auth0/management/log_streams.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class LogStreams(object):
+class LogStreams:
     """Auth0 log streams endpoints
 
     Args:

--- a/auth0/management/logs.py
+++ b/auth0/management/logs.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Logs(object):
+class Logs:
     """Auth0 logs endpoints
 
     Args:

--- a/auth0/management/organizations.py
+++ b/auth0/management/organizations.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Organizations(object):
+class Organizations:
     """Auth0 organizations endpoints
 
     Args:

--- a/auth0/management/prompts.py
+++ b/auth0/management/prompts.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Prompts(object):
+class Prompts:
     """Auth0 prompts endpoints
 
     Args:

--- a/auth0/management/resource_servers.py
+++ b/auth0/management/resource_servers.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class ResourceServers(object):
+class ResourceServers:
     """Auth0 resource servers endpoints
 
     Args:

--- a/auth0/management/roles.py
+++ b/auth0/management/roles.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Roles(object):
+class Roles:
     """Auth0 roles endpoints
 
     Args:

--- a/auth0/management/rules.py
+++ b/auth0/management/rules.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Rules(object):
+class Rules:
     """Rules endpoint implementation.
 
     Args:

--- a/auth0/management/rules_configs.py
+++ b/auth0/management/rules_configs.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class RulesConfigs(object):
+class RulesConfigs:
     """RulesConfig endpoint implementation.
 
     Args:

--- a/auth0/management/stats.py
+++ b/auth0/management/stats.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Stats(object):
+class Stats:
     """Auth0 stats endpoints
 
     Args:

--- a/auth0/management/tenants.py
+++ b/auth0/management/tenants.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Tenants(object):
+class Tenants:
     """Auth0 tenants endpoints
 
     Args:

--- a/auth0/management/tickets.py
+++ b/auth0/management/tickets.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class Tickets(object):
+class Tickets:
     """Auth0 tickets endpoints
 
     Args:

--- a/auth0/management/user_blocks.py
+++ b/auth0/management/user_blocks.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class UserBlocks(object):
+class UserBlocks:
     """Auth0 user blocks endpoints
 
     Args:

--- a/auth0/management/users.py
+++ b/auth0/management/users.py
@@ -3,7 +3,7 @@ import warnings
 from ..rest import RestClient
 
 
-class Users(object):
+class Users:
     """Auth0 users endpoints
 
     Args:

--- a/auth0/management/users_by_email.py
+++ b/auth0/management/users_by_email.py
@@ -1,7 +1,7 @@
 from ..rest import RestClient
 
 
-class UsersByEmail(object):
+class UsersByEmail:
     """Auth0 users by email endpoints
 
     Args:

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -286,9 +286,7 @@ class Response:
 class JsonResponse(Response):
     def __init__(self, response):
         content = json.loads(response.text)
-        super().__init__(
-            response.status_code, content, response.headers
-        )
+        super().__init__(response.status_code, content, response.headers)
 
     def _error_code(self):
         if "errorCode" in self._content:
@@ -311,9 +309,7 @@ class JsonResponse(Response):
 
 class PlainResponse(Response):
     def __init__(self, response):
-        super().__init__(
-            response.status_code, response.text, response.headers
-        )
+        super().__init__(response.status_code, response.text, response.headers)
 
     def _error_code(self):
         return UNKNOWN_ERROR

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -12,7 +12,7 @@ from auth0.exceptions import Auth0Error, RateLimitError
 UNKNOWN_ERROR = "a0.sdk.internal.unknown"
 
 
-class RestClientOptions(object):
+class RestClientOptions:
     """Configuration object for RestClient. Used for configuring
             additional RestClient options, such as rate-limit
             retries.
@@ -47,7 +47,7 @@ class RestClientOptions(object):
             self.retries = retries
 
 
-class RestClient(object):
+class RestClient:
     """Provides simple methods for handling all RESTful api endpoints.
 
     Args:
@@ -241,7 +241,7 @@ class RestClient(object):
             return PlainResponse(response)
 
 
-class Response(object):
+class Response:
     def __init__(self, status_code, content, headers):
         self._status_code = status_code
         self._content = content
@@ -286,7 +286,7 @@ class Response(object):
 class JsonResponse(Response):
     def __init__(self, response):
         content = json.loads(response.text)
-        super(JsonResponse, self).__init__(
+        super().__init__(
             response.status_code, content, response.headers
         )
 
@@ -311,7 +311,7 @@ class JsonResponse(Response):
 
 class PlainResponse(Response):
     def __init__(self, response):
-        super(PlainResponse, self).__init__(
+        super().__init__(
             response.status_code, response.text, response.headers
         )
 
@@ -324,7 +324,7 @@ class PlainResponse(Response):
 
 class EmptyResponse(Response):
     def __init__(self, status_code):
-        super(EmptyResponse, self).__init__(status_code, "", {})
+        super().__init__(status_code, "", {})
 
     def _error_code(self):
         return UNKNOWN_ERROR

--- a/auth0/rest_async.py
+++ b/auth0/rest_async.py
@@ -31,7 +31,7 @@ class AsyncRestClient(RestClient):
     """
 
     def __init__(self, *args, **kwargs):
-        super(AsyncRestClient, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._session = None
         sock_connect, sock_read = (
             self.timeout
@@ -128,7 +128,7 @@ class AsyncRestClient(RestClient):
             return PlainResponse(requests_response)
 
 
-class RequestsResponse(object):
+class RequestsResponse:
     def __init__(self, response, text):
         self.status_code = response.status
         self.headers = response.headers

--- a/auth0/test/authentication/test_base.py
+++ b/auth0/test/authentication/test_base.py
@@ -2,8 +2,8 @@ import base64
 import json
 import sys
 import unittest
-
 from unittest import mock
+
 import requests
 
 from ...authentication.base import AuthenticationBase

--- a/auth0/test/authentication/test_base.py
+++ b/auth0/test/authentication/test_base.py
@@ -3,7 +3,7 @@ import json
 import sys
 import unittest
 
-import mock
+from unittest import mock
 import requests
 
 from ...authentication.base import AuthenticationBase

--- a/auth0/test/authentication/test_database.py
+++ b/auth0/test/authentication/test_database.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...authentication.database import Database
 

--- a/auth0/test/authentication/test_database.py
+++ b/auth0/test/authentication/test_database.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...authentication.database import Database

--- a/auth0/test/authentication/test_delegated.py
+++ b/auth0/test/authentication/test_delegated.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...authentication.delegated import Delegated

--- a/auth0/test/authentication/test_delegated.py
+++ b/auth0/test/authentication/test_delegated.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...authentication.delegated import Delegated
 

--- a/auth0/test/authentication/test_enterprise.py
+++ b/auth0/test/authentication/test_enterprise.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...authentication.enterprise import Enterprise

--- a/auth0/test/authentication/test_enterprise.py
+++ b/auth0/test/authentication/test_enterprise.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...authentication.enterprise import Enterprise
 

--- a/auth0/test/authentication/test_get_token.py
+++ b/auth0/test/authentication/test_get_token.py
@@ -1,6 +1,6 @@
 import unittest
-
 from unittest import mock
+
 from callee.strings import Glob
 from cryptography.hazmat.primitives import asymmetric, serialization
 

--- a/auth0/test/authentication/test_get_token.py
+++ b/auth0/test/authentication/test_get_token.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 from callee.strings import Glob
 from cryptography.hazmat.primitives import asymmetric, serialization
 

--- a/auth0/test/authentication/test_passwordless.py
+++ b/auth0/test/authentication/test_passwordless.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...authentication.passwordless import Passwordless
 

--- a/auth0/test/authentication/test_passwordless.py
+++ b/auth0/test/authentication/test_passwordless.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...authentication.passwordless import Passwordless

--- a/auth0/test/authentication/test_revoke_token.py
+++ b/auth0/test/authentication/test_revoke_token.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...authentication.revoke_token import RevokeToken

--- a/auth0/test/authentication/test_revoke_token.py
+++ b/auth0/test/authentication/test_revoke_token.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...authentication.revoke_token import RevokeToken
 

--- a/auth0/test/authentication/test_social.py
+++ b/auth0/test/authentication/test_social.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...authentication.social import Social
 

--- a/auth0/test/authentication/test_social.py
+++ b/auth0/test/authentication/test_social.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...authentication.social import Social

--- a/auth0/test/authentication/test_token_verifier.py
+++ b/auth0/test/authentication/test_token_verifier.py
@@ -1,9 +1,9 @@
 import json
 import time
 import unittest
+from unittest.mock import MagicMock, patch
 
 import jwt
-from unittest.mock import MagicMock, patch
 
 from ...authentication.token_verifier import (
     AsymmetricSignatureVerifier,

--- a/auth0/test/authentication/test_token_verifier.py
+++ b/auth0/test/authentication/test_token_verifier.py
@@ -3,7 +3,7 @@ import time
 import unittest
 
 import jwt
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from ...authentication.token_verifier import (
     AsymmetricSignatureVerifier,

--- a/auth0/test/authentication/test_users.py
+++ b/auth0/test/authentication/test_users.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...authentication.users import Users
 

--- a/auth0/test/authentication/test_users.py
+++ b/auth0/test/authentication/test_users.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...authentication.users import Users

--- a/auth0/test/management/test_actions.py
+++ b/auth0/test/management/test_actions.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.actions import Actions
 

--- a/auth0/test/management/test_actions.py
+++ b/auth0/test/management/test_actions.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.actions import Actions

--- a/auth0/test/management/test_atack_protection.py
+++ b/auth0/test/management/test_atack_protection.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.attack_protection import AttackProtection

--- a/auth0/test/management/test_atack_protection.py
+++ b/auth0/test/management/test_atack_protection.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.attack_protection import AttackProtection
 

--- a/auth0/test/management/test_blacklists.py
+++ b/auth0/test/management/test_blacklists.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.blacklists import Blacklists
 

--- a/auth0/test/management/test_blacklists.py
+++ b/auth0/test/management/test_blacklists.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.blacklists import Blacklists

--- a/auth0/test/management/test_branding.py
+++ b/auth0/test/management/test_branding.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.branding import Branding

--- a/auth0/test/management/test_branding.py
+++ b/auth0/test/management/test_branding.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.branding import Branding
 

--- a/auth0/test/management/test_client_credentials.py
+++ b/auth0/test/management/test_client_credentials.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.client_credentials import ClientCredentials

--- a/auth0/test/management/test_client_credentials.py
+++ b/auth0/test/management/test_client_credentials.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.client_credentials import ClientCredentials
 

--- a/auth0/test/management/test_client_grants.py
+++ b/auth0/test/management/test_client_grants.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.client_grants import ClientGrants

--- a/auth0/test/management/test_client_grants.py
+++ b/auth0/test/management/test_client_grants.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.client_grants import ClientGrants
 

--- a/auth0/test/management/test_clients.py
+++ b/auth0/test/management/test_clients.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.clients import Clients

--- a/auth0/test/management/test_clients.py
+++ b/auth0/test/management/test_clients.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.clients import Clients
 

--- a/auth0/test/management/test_connections.py
+++ b/auth0/test/management/test_connections.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.connections import Connections
 

--- a/auth0/test/management/test_connections.py
+++ b/auth0/test/management/test_connections.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.connections import Connections

--- a/auth0/test/management/test_custom_domains.py
+++ b/auth0/test/management/test_custom_domains.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.custom_domains import CustomDomains
 

--- a/auth0/test/management/test_custom_domains.py
+++ b/auth0/test/management/test_custom_domains.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.custom_domains import CustomDomains

--- a/auth0/test/management/test_device_credentials.py
+++ b/auth0/test/management/test_device_credentials.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.device_credentials import DeviceCredentials
 

--- a/auth0/test/management/test_device_credentials.py
+++ b/auth0/test/management/test_device_credentials.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.device_credentials import DeviceCredentials

--- a/auth0/test/management/test_email_endpoints.py
+++ b/auth0/test/management/test_email_endpoints.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.email_templates import EmailTemplates
 

--- a/auth0/test/management/test_email_endpoints.py
+++ b/auth0/test/management/test_email_endpoints.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.email_templates import EmailTemplates

--- a/auth0/test/management/test_emails.py
+++ b/auth0/test/management/test_emails.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.emails import Emails
 

--- a/auth0/test/management/test_emails.py
+++ b/auth0/test/management/test_emails.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.emails import Emails

--- a/auth0/test/management/test_grants.py
+++ b/auth0/test/management/test_grants.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.grants import Grants

--- a/auth0/test/management/test_grants.py
+++ b/auth0/test/management/test_grants.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.grants import Grants
 

--- a/auth0/test/management/test_guardian.py
+++ b/auth0/test/management/test_guardian.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.guardian import Guardian

--- a/auth0/test/management/test_guardian.py
+++ b/auth0/test/management/test_guardian.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.guardian import Guardian
 

--- a/auth0/test/management/test_hooks.py
+++ b/auth0/test/management/test_hooks.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.hooks import Hooks

--- a/auth0/test/management/test_hooks.py
+++ b/auth0/test/management/test_hooks.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.hooks import Hooks
 

--- a/auth0/test/management/test_jobs.py
+++ b/auth0/test/management/test_jobs.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.jobs import Jobs
 

--- a/auth0/test/management/test_jobs.py
+++ b/auth0/test/management/test_jobs.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.jobs import Jobs

--- a/auth0/test/management/test_log_streams.py
+++ b/auth0/test/management/test_log_streams.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.log_streams import LogStreams

--- a/auth0/test/management/test_log_streams.py
+++ b/auth0/test/management/test_log_streams.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.log_streams import LogStreams
 

--- a/auth0/test/management/test_logs.py
+++ b/auth0/test/management/test_logs.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.logs import Logs

--- a/auth0/test/management/test_logs.py
+++ b/auth0/test/management/test_logs.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.logs import Logs
 

--- a/auth0/test/management/test_organizations.py
+++ b/auth0/test/management/test_organizations.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.organizations import Organizations

--- a/auth0/test/management/test_organizations.py
+++ b/auth0/test/management/test_organizations.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.organizations import Organizations
 

--- a/auth0/test/management/test_prompts.py
+++ b/auth0/test/management/test_prompts.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.prompts import Prompts
 

--- a/auth0/test/management/test_prompts.py
+++ b/auth0/test/management/test_prompts.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.prompts import Prompts

--- a/auth0/test/management/test_resource_servers.py
+++ b/auth0/test/management/test_resource_servers.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.resource_servers import ResourceServers
 

--- a/auth0/test/management/test_resource_servers.py
+++ b/auth0/test/management/test_resource_servers.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.resource_servers import ResourceServers

--- a/auth0/test/management/test_rest.py
+++ b/auth0/test/management/test_rest.py
@@ -3,7 +3,7 @@ import json
 import sys
 import unittest
 
-import mock
+from unittest import mock
 import requests
 
 from auth0.rest import RestClient, RestClientOptions

--- a/auth0/test/management/test_rest.py
+++ b/auth0/test/management/test_rest.py
@@ -2,8 +2,8 @@ import base64
 import json
 import sys
 import unittest
-
 from unittest import mock
+
 import requests
 
 from auth0.rest import RestClient, RestClientOptions

--- a/auth0/test/management/test_roles.py
+++ b/auth0/test/management/test_roles.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.roles import Roles
 

--- a/auth0/test/management/test_roles.py
+++ b/auth0/test/management/test_roles.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.roles import Roles

--- a/auth0/test/management/test_rules.py
+++ b/auth0/test/management/test_rules.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.rules import Rules

--- a/auth0/test/management/test_rules.py
+++ b/auth0/test/management/test_rules.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.rules import Rules
 

--- a/auth0/test/management/test_rules_configs.py
+++ b/auth0/test/management/test_rules_configs.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.rules_configs import RulesConfigs

--- a/auth0/test/management/test_rules_configs.py
+++ b/auth0/test/management/test_rules_configs.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.rules_configs import RulesConfigs
 

--- a/auth0/test/management/test_stats.py
+++ b/auth0/test/management/test_stats.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.stats import Stats
 

--- a/auth0/test/management/test_stats.py
+++ b/auth0/test/management/test_stats.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.stats import Stats

--- a/auth0/test/management/test_tenants.py
+++ b/auth0/test/management/test_tenants.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.tenants import Tenants
 

--- a/auth0/test/management/test_tenants.py
+++ b/auth0/test/management/test_tenants.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.tenants import Tenants

--- a/auth0/test/management/test_tickets.py
+++ b/auth0/test/management/test_tickets.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.tickets import Tickets

--- a/auth0/test/management/test_tickets.py
+++ b/auth0/test/management/test_tickets.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.tickets import Tickets
 

--- a/auth0/test/management/test_user_blocks.py
+++ b/auth0/test/management/test_user_blocks.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.user_blocks import UserBlocks

--- a/auth0/test/management/test_user_blocks.py
+++ b/auth0/test/management/test_user_blocks.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.user_blocks import UserBlocks
 

--- a/auth0/test/management/test_users.py
+++ b/auth0/test/management/test_users.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.users import Users

--- a/auth0/test/management/test_users.py
+++ b/auth0/test/management/test_users.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.users import Users
 

--- a/auth0/test/management/test_users_by_email.py
+++ b/auth0/test/management/test_users_by_email.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 
 from ...management.users_by_email import UsersByEmail
 

--- a/auth0/test/management/test_users_by_email.py
+++ b/auth0/test/management/test_users_by_email.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from ...management.users_by_email import UsersByEmail

--- a/auth0/test_async/test_async_auth0.py
+++ b/auth0/test_async/test_async_auth0.py
@@ -1,9 +1,9 @@
 import re
 import unittest
+from unittest.mock import ANY, MagicMock
 
 from aioresponses import CallbackResult, aioresponses
 from callee import Attrs
-from unittest.mock import ANY, MagicMock
 
 from auth0.management.async_auth0 import AsyncAuth0 as Auth0
 

--- a/auth0/test_async/test_async_auth0.py
+++ b/auth0/test_async/test_async_auth0.py
@@ -3,7 +3,7 @@ import unittest
 
 from aioresponses import CallbackResult, aioresponses
 from callee import Attrs
-from mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock
 
 from auth0.management.async_auth0 import AsyncAuth0 as Auth0
 

--- a/auth0/test_async/test_async_token_verifier.py
+++ b/auth0/test_async/test_async_token_verifier.py
@@ -5,7 +5,7 @@ import jwt
 from aioresponses import aioresponses
 from callee import Attrs
 from cryptography.hazmat.primitives import serialization
-from mock import ANY
+from unittest.mock import ANY
 
 from .. import TokenValidationError
 from ..authentication.async_token_verifier import (

--- a/auth0/test_async/test_async_token_verifier.py
+++ b/auth0/test_async/test_async_token_verifier.py
@@ -1,11 +1,11 @@
 import time
 import unittest
+from unittest.mock import ANY
 
 import jwt
 from aioresponses import aioresponses
 from callee import Attrs
 from cryptography.hazmat.primitives import serialization
-from unittest.mock import ANY
 
 from .. import TokenValidationError
 from ..authentication.async_token_verifier import (

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryFile
 import aiohttp
 from aioresponses import CallbackResult, aioresponses
 from callee import Attrs
-from mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock
 
 from auth0.asyncify import asyncify
 from auth0.management import Clients, Guardian, Jobs

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -5,11 +5,11 @@ import re
 import sys
 import unittest
 from tempfile import TemporaryFile
+from unittest.mock import ANY, MagicMock
 
 import aiohttp
 from aioresponses import CallbackResult, aioresponses
 from callee import Attrs
-from unittest.mock import ANY, MagicMock
 
 from auth0.asyncify import asyncify
 from auth0.management import Clients, Guardian, Jobs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,6 @@
 
 # -- Path setup --------------------------------------------------------------
 
-import io
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -22,7 +20,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 
 # -- helper function to read a file without importing it
 def read(*names, **kwargs):
-    with io.open(
+    with open(
         os.path.join(os.path.dirname(__file__)[:-7], *names),
         encoding=kwargs.get("encoding", "utf8"),
     ) as fp:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import io
 import os
 import re
 
@@ -7,7 +6,7 @@ from setuptools import find_packages, setup
 
 def find_version():
     file_dir = os.path.dirname(__file__)
-    with io.open(os.path.join(file_dir, "auth0", "__init__.py")) as f:
+    with open(os.path.join(file_dir, "auth0", "__init__.py")) as f:
         version = re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]', f.read())
         if version:
             return version.group(1)
@@ -15,7 +14,7 @@ def find_version():
             raise RuntimeError("Unable to find version string.")
 
 
-with io.open("README.md", encoding="utf-8") as f:
+with open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
 
@@ -30,7 +29,7 @@ setup(
     license="MIT",
     packages=find_packages(),
     install_requires=["requests>=2.14.0", "pyjwt[crypto]>=2.6.0"],
-    extras_require={"test": ["coverage", "mock>=1.3.0", "pre-commit"]},
+    extras_require={"test": ["coverage", "pre-commit"]},
     python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Also removed the `mock` dependency, as it is included in Python.

- The other thing that could be updated is `f-strings` (vs. `.format()`), just let me know if you'd like to update those.
- This part could also be updated, as Python>=3.7 is now required:
  https://github.com/auth0/auth0-python/blob/bdd07e3956b6304e3010c04b27b67e8ab7607f8e/auth0/utils.py#L4-L15
### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
