### PR TITLE
Use `f-strings` instead of `.format()`

### DIFF
--- a/auth0/asyncify.py
+++ b/auth0/asyncify.py
@@ -66,7 +66,7 @@ def asyncify(cls):
             for method in methods:
                 setattr(
                     self,
-                    "{}_async".format(method),
+                    f"{method}_async",
                     _gen_async(self._async_client, method),
                 )
 

--- a/auth0/authentication/async_token_verifier.py
+++ b/auth0/authentication/async_token_verifier.py
@@ -111,9 +111,7 @@ class AsyncJwksFetcher(JwksFetcher):
             keys = await self._fetch_jwks(force=True)
             if keys and key_id in keys:
                 return keys[key_id]
-        raise TokenValidationError(
-            'RSA Public Key with ID "{}" was not found.'.format(key_id)
-        )
+        raise TokenValidationError(f'RSA Public Key with ID "{key_id}" was not found.')
 
 
 class AsyncTokenVerifier(TokenVerifier):

--- a/auth0/authentication/client_authentication.py
+++ b/auth0/authentication/client_authentication.py
@@ -24,7 +24,7 @@ def create_client_assertion_jwt(
         {
             "iss": client_id,
             "sub": client_id,
-            "aud": "https://{}/".format(domain),
+            "aud": f"https://{domain}/",
             "iat": now,
             "exp": now + datetime.timedelta(seconds=180),
             "jti": str(uuid.uuid4()),

--- a/auth0/authentication/database.py
+++ b/auth0/authentication/database.py
@@ -72,7 +72,7 @@ class Database(AuthenticationBase):
             body.update({"picture": picture})
 
         return self.post(
-            "{}://{}/dbconnections/signup".format(self.protocol, self.domain), data=body
+            f"{self.protocol}://{self.domain}/dbconnections/signup", data=body
         )
 
     def change_password(self, email, connection, password=None):
@@ -89,6 +89,6 @@ class Database(AuthenticationBase):
         }
 
         return self.post(
-            "{}://{}/dbconnections/change_password".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/dbconnections/change_password",
             data=body,
         )

--- a/auth0/authentication/delegated.py
+++ b/auth0/authentication/delegated.py
@@ -38,6 +38,4 @@ class Delegated(AuthenticationBase):
         else:
             raise ValueError("Either id_token or refresh_token must have a value")
 
-        return self.post(
-            "{}://{}/delegation".format(self.protocol, self.domain), data=data
-        )
+        return self.post(f"{self.protocol}://{self.domain}/delegation", data=data)

--- a/auth0/authentication/get_token.py
+++ b/auth0/authentication/get_token.py
@@ -36,7 +36,7 @@ class GetToken(AuthenticationBase):
         """
 
         return self.authenticated_post(
-            "{}://{}/oauth/token".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/oauth/token",
             data={
                 "client_id": self.client_id,
                 "code": code,
@@ -74,7 +74,7 @@ class GetToken(AuthenticationBase):
         """
 
         return self.post(
-            "{}://{}/oauth/token".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/oauth/token",
             data={
                 "client_id": self.client_id,
                 "code_verifier": code_verifier,
@@ -106,7 +106,7 @@ class GetToken(AuthenticationBase):
         """
 
         return self.authenticated_post(
-            "{}://{}/oauth/token".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/oauth/token",
             data={
                 "client_id": self.client_id,
                 "audience": audience,
@@ -154,7 +154,7 @@ class GetToken(AuthenticationBase):
         """
 
         return self.authenticated_post(
-            "{}://{}/oauth/token".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/oauth/token",
             data={
                 "client_id": self.client_id,
                 "username": username,
@@ -190,7 +190,7 @@ class GetToken(AuthenticationBase):
         """
 
         return self.authenticated_post(
-            "{}://{}/oauth/token".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/oauth/token",
             data={
                 "client_id": self.client_id,
                 "refresh_token": refresh_token,
@@ -223,7 +223,7 @@ class GetToken(AuthenticationBase):
         """
 
         return self.authenticated_post(
-            "{}://{}/oauth/token".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/oauth/token",
             data={
                 "client_id": self.client_id,
                 "username": username,

--- a/auth0/authentication/passwordless.py
+++ b/auth0/authentication/passwordless.py
@@ -45,7 +45,7 @@ class Passwordless(AuthenticationBase):
             data.update({"authParams": auth_params})
 
         return self.authenticated_post(
-            "{}://{}/passwordless/start".format(self.protocol, self.domain), data=data
+            f"{self.protocol}://{self.domain}/passwordless/start", data=data
         )
 
     def sms(self, phone_number):
@@ -68,5 +68,5 @@ class Passwordless(AuthenticationBase):
         }
 
         return self.authenticated_post(
-            "{}://{}/passwordless/start".format(self.protocol, self.domain), data=data
+            f"{self.protocol}://{self.domain}/passwordless/start", data=data
         )

--- a/auth0/authentication/revoke_token.py
+++ b/auth0/authentication/revoke_token.py
@@ -26,5 +26,5 @@ class RevokeToken(AuthenticationBase):
         }
 
         return self.authenticated_post(
-            "{}://{}/oauth/revoke".format(self.protocol, self.domain), data=body
+            f"{self.protocol}://{self.domain}/oauth/revoke", data=body
         )

--- a/auth0/authentication/social.py
+++ b/auth0/authentication/social.py
@@ -27,7 +27,7 @@ class Social(AuthenticationBase):
         """
 
         return self.post(
-            "{}://{}/oauth/access_token".format(self.protocol, self.domain),
+            f"{self.protocol}://{self.domain}/oauth/access_token",
             data={
                 "client_id": self.client_id,
                 "access_token": access_token,

--- a/auth0/authentication/token_verifier.py
+++ b/auth0/authentication/token_verifier.py
@@ -236,9 +236,7 @@ class JwksFetcher:
             keys = self._fetch_jwks(force=True)
             if keys and key_id in keys:
                 return keys[key_id]
-        raise TokenValidationError(
-            'RSA Public Key with ID "{}" was not found.'.format(key_id)
-        )
+        raise TokenValidationError(f'RSA Public Key with ID "{key_id}" was not found.')
 
 
 class TokenVerifier:

--- a/auth0/authentication/users.py
+++ b/auth0/authentication/users.py
@@ -44,6 +44,6 @@ class Users:
         """
 
         return self.client.get(
-            url="{}://{}/userinfo".format(self.protocol, self.domain),
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            url=f"{self.protocol}://{self.domain}/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
         )

--- a/auth0/exceptions.py
+++ b/auth0/exceptions.py
@@ -6,7 +6,7 @@ class Auth0Error(Exception):
         self.content = content
 
     def __str__(self):
-        return "{}: {}".format(self.status_code, self.message)
+        return f"{self.status_code}: {self.message}"
 
 
 class RateLimitError(Auth0Error):

--- a/auth0/management/actions.py
+++ b/auth0/management/actions.py
@@ -39,10 +39,10 @@ class Actions:
         )
 
     def _url(self, *args):
-        url = "{}://{}/api/v2/actions".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/actions"
         for p in args:
             if p is not None:
-                url = "{}/{}".format(url, p)
+                url = f"{url}/{p}"
         return url
 
     def get_actions(

--- a/auth0/management/blacklists.py
+++ b/auth0/management/blacklists.py
@@ -32,7 +32,7 @@ class Blacklists:
         protocol="https",
         rest_options=None,
     ):
-        self.url = "{}://{}/api/v2/blacklists/tokens".format(protocol, domain)
+        self.url = f"{protocol}://{domain}/api/v2/blacklists/tokens"
         self.client = RestClient(
             jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options
         )

--- a/auth0/management/branding.py
+++ b/auth0/management/branding.py
@@ -39,10 +39,10 @@ class Branding:
         )
 
     def _url(self, *args):
-        url = "{}://{}/api/v2/branding".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/branding"
         for p in args:
             if p is not None:
-                url = "{}/{}".format(url, p)
+                url = f"{url}/{p}"
         return url
 
     def get(self, aud=None):

--- a/auth0/management/client_credentials.py
+++ b/auth0/management/client_credentials.py
@@ -43,7 +43,7 @@ class ClientCredentials:
             self.protocol, self.domain, client_id
         )
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def all(self, client_id):

--- a/auth0/management/client_grants.py
+++ b/auth0/management/client_grants.py
@@ -39,9 +39,9 @@ class ClientGrants:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/client-grants".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/client-grants"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def all(

--- a/auth0/management/clients.py
+++ b/auth0/management/clients.py
@@ -39,9 +39,9 @@ class Clients:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/clients".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/clients"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def all(

--- a/auth0/management/connections.py
+++ b/auth0/management/connections.py
@@ -39,9 +39,9 @@ class Connections:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/connections".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/connections"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def all(

--- a/auth0/management/custom_domains.py
+++ b/auth0/management/custom_domains.py
@@ -39,7 +39,7 @@ class CustomDomains:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/custom-domains".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/custom-domains"
         if id is not None:
             return url + "/" + id
         return url

--- a/auth0/management/device_credentials.py
+++ b/auth0/management/device_credentials.py
@@ -39,9 +39,9 @@ class DeviceCredentials:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/device-credentials".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/device-credentials"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def get(

--- a/auth0/management/email_templates.py
+++ b/auth0/management/email_templates.py
@@ -39,9 +39,9 @@ class EmailTemplates:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/email-templates".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/email-templates"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def create(self, body):

--- a/auth0/management/emails.py
+++ b/auth0/management/emails.py
@@ -39,9 +39,9 @@ class Emails:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/emails/provider".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/emails/provider"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def get(self, fields=None, include_fields=True):

--- a/auth0/management/grants.py
+++ b/auth0/management/grants.py
@@ -39,7 +39,7 @@ class Grants:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/grants".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/grants"
         if id is not None:
             return url + "/" + id
         return url

--- a/auth0/management/guardian.py
+++ b/auth0/management/guardian.py
@@ -39,9 +39,9 @@ class Guardian:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/guardian".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/guardian"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def all_factors(self):
@@ -64,7 +64,7 @@ class Guardian:
 
         See: https://auth0.com/docs/api/management/v2#!/Guardian/put_factors_by_name
         """
-        url = self._url("factors/{}".format(name))
+        url = self._url(f"factors/{name}")
         return self.client.put(url, data=body)
 
     def update_templates(self, body):
@@ -100,7 +100,7 @@ class Guardian:
 
         See: https://auth0.com/docs/api/management/v2#!/Guardian/get_enrollments_by_id
         """
-        url = self._url("enrollments/{}".format(id))
+        url = self._url(f"enrollments/{id}")
         return self.client.get(url)
 
     def delete_enrollment(self, id):
@@ -113,7 +113,7 @@ class Guardian:
 
         See: https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id
         """
-        url = self._url("enrollments/{}".format(id))
+        url = self._url(f"enrollments/{id}")
         return self.client.delete(url)
 
     def create_enrollment_ticket(self, body):
@@ -142,7 +142,7 @@ class Guardian:
         See: https://auth0.com/docs/api/management/v2#!/Guardian/get_sns
              https://auth0.com/docs/api/management/v2#!/Guardian/get_twilio
         """
-        url = self._url("factors/{}/providers/{}".format(factor_name, name))
+        url = self._url(f"factors/{factor_name}/providers/{name}")
         return self.client.get(url)
 
     def update_factor_providers(self, factor_name, name, body):
@@ -159,5 +159,5 @@ class Guardian:
 
         See: https://auth0.com/docs/api/management/v2#!/Guardian/put_twilio
         """
-        url = self._url("factors/{}/providers/{}".format(factor_name, name))
+        url = self._url(f"factors/{factor_name}/providers/{name}")
         return self.client.put(url, data=body)

--- a/auth0/management/hooks.py
+++ b/auth0/management/hooks.py
@@ -40,9 +40,9 @@ class Hooks:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/hooks".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/hooks"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def all(

--- a/auth0/management/jobs.py
+++ b/auth0/management/jobs.py
@@ -41,9 +41,9 @@ class Jobs:
         )
 
     def _url(self, path=None):
-        url = "{}://{}/api/v2/jobs".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/jobs"
         if path is not None:
-            return "{}/{}".format(url, path)
+            return f"{url}/{path}"
         return url
 
     def get(self, id):
@@ -64,7 +64,7 @@ class Jobs:
 
         See: https://auth0.com/docs/api/management/v2#!/Jobs/get_errors
         """
-        url = self._url("{}/errors".format(id))
+        url = self._url(f"{id}/errors")
         return self.client.get(url)
 
     def export_users(self, body):

--- a/auth0/management/log_streams.py
+++ b/auth0/management/log_streams.py
@@ -39,9 +39,9 @@ class LogStreams:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/log-streams".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/log-streams"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def list(self):

--- a/auth0/management/logs.py
+++ b/auth0/management/logs.py
@@ -39,9 +39,9 @@ class Logs:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/logs".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/logs"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def search(

--- a/auth0/management/organizations.py
+++ b/auth0/management/organizations.py
@@ -39,10 +39,10 @@ class Organizations:
         )
 
     def _url(self, *args):
-        url = "{}://{}/api/v2/organizations".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/organizations"
         for p in args:
             if p is not None:
-                url = "{}/{}".format(url, p)
+                url = f"{url}/{p}"
         return url
 
     # Organizations

--- a/auth0/management/prompts.py
+++ b/auth0/management/prompts.py
@@ -39,9 +39,9 @@ class Prompts:
         )
 
     def _url(self, prompt=None, language=None):
-        url = "{}://{}/api/v2/prompts".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/prompts"
         if prompt is not None and language is not None:
-            return "{}/{}/custom-text/{}".format(url, prompt, language)
+            return f"{url}/{prompt}/custom-text/{language}"
         return url
 
     def get(self):

--- a/auth0/management/resource_servers.py
+++ b/auth0/management/resource_servers.py
@@ -39,9 +39,9 @@ class ResourceServers:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/resource-servers".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/resource-servers"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def create(self, body):

--- a/auth0/management/roles.py
+++ b/auth0/management/roles.py
@@ -39,9 +39,9 @@ class Roles:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/roles".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/roles"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def list(self, page=0, per_page=25, include_totals=True, name_filter=None):
@@ -147,7 +147,7 @@ class Roles:
             "take": take,
         }
 
-        url = self._url("{}/users".format(id))
+        url = self._url(f"{id}/users")
         return self.client.get(url, params=params)
 
     def add_users(self, id, users):
@@ -160,7 +160,7 @@ class Roles:
 
         See https://auth0.com/docs/api/management/v2#!/Roles/post_role_users
         """
-        url = self._url("{}/users".format(id))
+        url = self._url(f"{id}/users")
         body = {"users": users}
         return self.client.post(url, data=body)
 
@@ -186,7 +186,7 @@ class Roles:
             "page": page,
             "include_totals": str(include_totals).lower(),
         }
-        url = self._url("{}/permissions".format(id))
+        url = self._url(f"{id}/permissions")
         return self.client.get(url, params=params)
 
     def remove_permissions(self, id, permissions):
@@ -199,7 +199,7 @@ class Roles:
 
         See https://auth0.com/docs/api/management/v2#!/Roles/delete_role_permission_assignment
         """
-        url = self._url("{}/permissions".format(id))
+        url = self._url(f"{id}/permissions")
         body = {"permissions": permissions}
         return self.client.delete(url, data=body)
 
@@ -213,6 +213,6 @@ class Roles:
 
         See https://auth0.com/docs/api/management/v2#!/Roles/post_role_permission_assignment
         """
-        url = self._url("{}/permissions".format(id))
+        url = self._url(f"{id}/permissions")
         body = {"permissions": permissions}
         return self.client.post(url, data=body)

--- a/auth0/management/rules.py
+++ b/auth0/management/rules.py
@@ -39,9 +39,9 @@ class Rules:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/rules".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/rules"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def all(

--- a/auth0/management/rules_configs.py
+++ b/auth0/management/rules_configs.py
@@ -39,7 +39,7 @@ class RulesConfigs:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/rules-configs".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/rules-configs"
         if id is not None:
             return url + "/" + id
         return url
@@ -71,6 +71,6 @@ class RulesConfigs:
 
         See: https://auth0.com/docs/api/management/v2#!/Rules_Configs/put_rules_configs_by_key
         """
-        url = self._url("{}".format(key))
+        url = self._url(f"{key}")
         body = {"value": value}
         return self.client.put(url, data=body)

--- a/auth0/management/stats.py
+++ b/auth0/management/stats.py
@@ -39,7 +39,7 @@ class Stats:
         )
 
     def _url(self, action):
-        return "{}://{}/api/v2/stats/{}".format(self.protocol, self.domain, action)
+        return f"{self.protocol}://{self.domain}/api/v2/stats/{action}"
 
     def active_users(self):
         """Gets the active users count (logged in during the last 30 days).

--- a/auth0/management/tenants.py
+++ b/auth0/management/tenants.py
@@ -39,7 +39,7 @@ class Tenants:
         )
 
     def _url(self):
-        return "{}://{}/api/v2/tenants/settings".format(self.protocol, self.domain)
+        return f"{self.protocol}://{self.domain}/api/v2/tenants/settings"
 
     def get(self, fields=None, include_fields=True):
         """Get tenant settings.

--- a/auth0/management/tickets.py
+++ b/auth0/management/tickets.py
@@ -39,7 +39,7 @@ class Tickets:
         )
 
     def _url(self, action):
-        return "{}://{}/api/v2/tickets/{}".format(self.protocol, self.domain, action)
+        return f"{self.protocol}://{self.domain}/api/v2/tickets/{action}"
 
     def create_email_verification(self, body):
         """Create an email verification ticket.

--- a/auth0/management/user_blocks.py
+++ b/auth0/management/user_blocks.py
@@ -39,9 +39,9 @@ class UserBlocks:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/user-blocks".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/user-blocks"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def get_by_identifier(self, identifier):

--- a/auth0/management/users.py
+++ b/auth0/management/users.py
@@ -41,9 +41,9 @@ class Users:
         )
 
     def _url(self, id=None):
-        url = "{}://{}/api/v2/users".format(self.protocol, self.domain)
+        url = f"{self.protocol}://{self.domain}/api/v2/users"
         if id is not None:
-            return "{}/{}".format(url, id)
+            return f"{url}/{id}"
         return url
 
     def list(
@@ -183,7 +183,7 @@ class Users:
             "include_totals": str(include_totals).lower(),
         }
 
-        url = self._url("{}/organizations".format(id))
+        url = self._url(f"{id}/organizations")
         return self.client.get(url, params=params)
 
     def list_roles(self, id, page=0, per_page=25, include_totals=True):
@@ -209,7 +209,7 @@ class Users:
             "include_totals": str(include_totals).lower(),
         }
 
-        url = self._url("{}/roles".format(id))
+        url = self._url(f"{id}/roles")
         return self.client.get(url, params=params)
 
     def remove_roles(self, id, roles):
@@ -222,7 +222,7 @@ class Users:
 
         See https://auth0.com/docs/api/management/v2#!/Users/delete_user_roles
         """
-        url = self._url("{}/roles".format(id))
+        url = self._url(f"{id}/roles")
         body = {"roles": roles}
         return self.client.delete(url, data=body)
 
@@ -236,7 +236,7 @@ class Users:
 
         See https://auth0.com/docs/api/management/v2#!/Users/post_user_roles
         """
-        url = self._url("{}/roles".format(id))
+        url = self._url(f"{id}/roles")
         body = {"roles": roles}
         return self.client.post(url, data=body)
 
@@ -263,7 +263,7 @@ class Users:
             "page": page,
             "include_totals": str(include_totals).lower(),
         }
-        url = self._url("{}/permissions".format(id))
+        url = self._url(f"{id}/permissions")
         return self.client.get(url, params=params)
 
     def remove_permissions(self, id, permissions):
@@ -276,7 +276,7 @@ class Users:
 
         See https://auth0.com/docs/api/management/v2#!/Users/delete_permissions
         """
-        url = self._url("{}/permissions".format(id))
+        url = self._url(f"{id}/permissions")
         body = {"permissions": permissions}
         return self.client.delete(url, data=body)
 
@@ -290,7 +290,7 @@ class Users:
 
         See https://auth0.com/docs/api/management/v2#!/Users/post_permissions
         """
-        url = self._url("{}/permissions".format(id))
+        url = self._url(f"{id}/permissions")
         body = {"permissions": permissions}
         return self.client.post(url, data=body)
 
@@ -305,7 +305,7 @@ class Users:
 
         See: https://auth0.com/docs/api/management/v2#!/Users/delete_multifactor_by_provider
         """
-        url = self._url("{}/multifactor/{}".format(id, provider))
+        url = self._url(f"{id}/multifactor/{provider}")
         return self.client.delete(url)
 
     def delete_authenticators(self, id):
@@ -316,7 +316,7 @@ class Users:
 
         See: https://auth0.com/docs/api/management/v2#!/Users/delete_authenticators
         """
-        url = self._url("{}/authenticators".format(id))
+        url = self._url(f"{id}/authenticators")
         return self.client.delete(url)
 
     def unlink_user_account(self, id, provider, user_id):
@@ -331,7 +331,7 @@ class Users:
 
         See: https://auth0.com/docs/api/management/v2#!/Users/delete_user_identity_by_user_id
         """
-        url = self._url("{}/identities/{}/{}".format(id, provider, user_id))
+        url = self._url(f"{id}/identities/{provider}/{user_id}")
         return self.client.delete(url)
 
     def link_user_account(self, user_id, body):
@@ -348,7 +348,7 @@ class Users:
 
         See: https://auth0.com/docs/api/v2#!/Users/post_identities
         """
-        url = self._url("{}/identities".format(user_id))
+        url = self._url(f"{user_id}/identities")
         return self.client.post(url, data=body)
 
     def regenerate_recovery_code(self, user_id):
@@ -359,7 +359,7 @@ class Users:
 
         See: https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration
         """
-        url = self._url("{}/recovery-code-regeneration".format(user_id))
+        url = self._url(f"{user_id}/recovery-code-regeneration")
         return self.client.post(url)
 
     def get_guardian_enrollments(self, user_id):
@@ -370,7 +370,7 @@ class Users:
 
         See: https://auth0.com/docs/api/management/v2#!/Users/get_enrollments
         """
-        url = self._url("{}/enrollments".format(user_id))
+        url = self._url(f"{user_id}/enrollments")
         return self.client.get(url)
 
     def get_log_events(
@@ -405,7 +405,7 @@ class Users:
             "sort": sort,
         }
 
-        url = self._url("{}/logs".format(user_id))
+        url = self._url(f"{user_id}/logs")
         return self.client.get(url, params=params)
 
     def invalidate_remembered_browsers(self, user_id):
@@ -417,7 +417,5 @@ class Users:
         See: https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser
         """
 
-        url = self._url(
-            "{}/multifactor/actions/invalidate-remember-browser".format(user_id)
-        )
+        url = self._url(f"{user_id}/multifactor/actions/invalidate-remember-browser")
         return self.client.post(url)

--- a/auth0/management/users_by_email.py
+++ b/auth0/management/users_by_email.py
@@ -39,7 +39,7 @@ class UsersByEmail:
         )
 
     def _url(self):
-        return "{}://{}/api/v2/users-by-email".format(self.protocol, self.domain)
+        return f"{self.protocol}://{self.domain}/api/v2/users-by-email"
 
     def search_users_by_email(self, email, fields=None, include_fields=True):
         """List or search users.

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -79,7 +79,7 @@ class RestClient:
         }
 
         if jwt is not None:
-            self.base_headers["Authorization"] = "Bearer {}".format(self.jwt)
+            self.base_headers["Authorization"] = f"Bearer {self.jwt}"
 
         if options.telemetry:
             py_version = platform.python_version()
@@ -97,7 +97,7 @@ class RestClient:
 
             self.base_headers.update(
                 {
-                    "User-Agent": "Python/{}".format(py_version),
+                    "User-Agent": f"Python/{py_version}",
                     "Auth0-Client": base64.b64encode(auth0_client).decode(),
                 }
             )

--- a/auth0/test/authentication/test_base.py
+++ b/auth0/test/authentication/test_base.py
@@ -33,7 +33,7 @@ class TestBase(unittest.TestCase):
             "env": {"python": python_version},
         }
 
-        self.assertEqual(user_agent, "Python/{}".format(python_version))
+        self.assertEqual(user_agent, f"Python/{python_version}")
         self.assertEqual(auth0_client, client_info)
         self.assertEqual(content_type, "application/json")
 

--- a/auth0/test/management/test_rest.py
+++ b/auth0/test/management/test_rest.py
@@ -791,6 +791,6 @@ class TestRest(unittest.TestCase):
             "env": {"python": python_version},
         }
 
-        self.assertEqual(user_agent, "Python/{}".format(python_version))
+        self.assertEqual(user_agent, f"Python/{python_version}")
         self.assertEqual(auth0_client, client_info)
         self.assertEqual(content_type, "application/json")

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -32,7 +32,7 @@ telemetry = base64.b64encode(
 ).decode()
 
 headers = {
-    "User-Agent": "Python/{}".format(platform.python_version()),
+    "User-Agent": f"Python/{platform.python_version()}",
     "Authorization": "Bearer jwt",
     "Content-Type": "application/json",
     "Auth0-Client": telemetry,

--- a/auth0/utils.py
+++ b/auth0/utils.py
@@ -1,15 +1,11 @@
-import sys
-
-
 def is_async_available():
-    if sys.version_info >= (3, 6):
-        try:
-            import asyncio
+    try:
+        import asyncio
 
-            import aiohttp
+        import aiohttp
 
-            return True
-        except ImportError:  # pragma: no cover
-            pass
+        return True
+    except ImportError:  # pragma: no cover
+        pass
 
     return False


### PR DESCRIPTION
Using [`pyupgrade`](https://github.com/asottile/pyupgrade) with the following command:

```sh
pyupgrade --py37-plus  `find . -name "*.py"`
```

- Converted `.format` to `f-strings`
- Simplify `is_async_available` in `utils.py`

You might want to keep `.format` in some places, as it could be easier to read

*note: pyupgrade is intentionally timid and will not create an f-string if it would make the expression longer or if the substitution parameters are sufficiently complicated (as this can decrease readability).*