### PR TITLE
Removed legacy example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,6 @@ The Authentication SDK is organized into components that mirror the structure of
 [API documentation](https://auth0.com/docs/auth-api).
 For example:
 
-```python
-from auth0.authentication import Social
-
-social = Social('my-domain.us.auth0.com', 'my-client-id')
-
-social.login(access_token='...', connection='facebook')
-```
-
 If you need to sign up a user using their email and password, you can use the Database object.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ pip install auth0-python
 #### Authentication SDK
 The Authentication SDK is organized into components that mirror the structure of the
 [API documentation](https://auth0.com/docs/auth-api).
-For example:
 
 If you need to sign up a user using their email and password, you can use the Database object.
 


### PR DESCRIPTION
### Changes

Removed legacy example from README. 

### References

A Community user ran into it [here](https://community.auth0.com/t/google-oauth2-login-with-python-package-encountered-weird-error/97913/) and I spoke to @adamjmcgrath on Slack to confirm.