### PR TITLE
Add type hints to base and `authentication`

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -7,7 +7,7 @@
   - [Connections](#connections)
 - [Error handling](#error-handling)
 - [Asynchronous environments](#asynchronous-environments)
-  
+
 ## Authentication SDK
 
 ### ID token validation

--- a/auth0/authentication/async_token_verifier.py
+++ b/auth0/authentication/async_token_verifier.py
@@ -40,7 +40,7 @@ class AsyncAsymmetricSignatureVerifier(AsymmetricSignatureVerifier):
         key_id (str): The key's key id."""
         return await self._fetcher.get_key(key_id)
 
-    async def verify_signature(self, token):
+    async def verify_signature(self, token) -> dict[str, Any]:
         """Verifies the signature of the given JSON web token.
 
         Args:

--- a/auth0/authentication/base.py
+++ b/auth0/authentication/base.py
@@ -67,7 +67,7 @@ class AuthenticationBase:
     def authenticated_post(
         self,
         url: str,
-        data: dict[str, Any] | None = None,
+        data: dict[str, Any],
         headers: dict[str, str] | None = None,
     ) -> Any:
         return self.client.post(

--- a/auth0/authentication/base.py
+++ b/auth0/authentication/base.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
+from typing import Any
+
 from auth0.rest import RestClient, RestClientOptions
+from auth0.types import RequestData, TimeoutType
 
 from .client_authentication import add_client_authentication
 
@@ -21,15 +26,15 @@ class AuthenticationBase:
 
     def __init__(
         self,
-        domain,
-        client_id,
-        client_secret=None,
-        client_assertion_signing_key=None,
-        client_assertion_signing_alg=None,
-        telemetry=True,
-        timeout=5.0,
-        protocol="https",
-    ):
+        domain: str,
+        client_id: str,
+        client_secret: str | None = None,
+        client_assertion_signing_key: str | None = None,
+        client_assertion_signing_alg: str | None = None,
+        telemetry: bool = True,
+        timeout: TimeoutType = 5.0,
+        protocol: str = "https",
+    ) -> None:
         self.domain = domain
         self.client_id = client_id
         self.client_secret = client_secret
@@ -41,7 +46,7 @@ class AuthenticationBase:
             options=RestClientOptions(telemetry=telemetry, timeout=timeout, retries=0),
         )
 
-    def _add_client_authentication(self, payload):
+    def _add_client_authentication(self, payload: dict[str, Any]) -> dict[str, Any]:
         return add_client_authentication(
             payload,
             self.domain,
@@ -51,13 +56,28 @@ class AuthenticationBase:
             self.client_assertion_signing_alg,
         )
 
-    def post(self, url, data=None, headers=None):
+    def post(
+        self,
+        url: str,
+        data: RequestData | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
         return self.client.post(url, data=data, headers=headers)
 
-    def authenticated_post(self, url, data=None, headers=None):
+    def authenticated_post(
+        self,
+        url: str,
+        data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
         return self.client.post(
             url, data=self._add_client_authentication(data), headers=headers
         )
 
-    def get(self, url, params=None, headers=None):
+    def get(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
         return self.client.get(url, params, headers)

--- a/auth0/authentication/client_authentication.py
+++ b/auth0/authentication/client_authentication.py
@@ -44,7 +44,7 @@ def add_client_authentication(
     payload: dict[str, Any],
     domain: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     client_assertion_signing_key: str | None,
     client_assertion_signing_alg: str | None,
 ) -> dict[str, Any]:
@@ -54,7 +54,7 @@ def add_client_authentication(
         payload (dict): The POST payload that needs additional fields to be authenticated.
         domain (str): The domain of your Auth0 tenant
         client_id (str): Your application's client ID
-        client_secret (str): Your application's client secret
+        client_secret (str, optional): Your application's client secret
         client_assertion_signing_key (str, optional): Private key used to sign the client assertion JWT
         client_assertion_signing_alg (str, optional): Algorithm used to sign the client assertion JWT (defaults to 'RS256')
 

--- a/auth0/authentication/client_authentication.py
+++ b/auth0/authentication/client_authentication.py
@@ -10,7 +10,7 @@ import jwt
 def create_client_assertion_jwt(
     domain: str,
     client_id: str,
-    client_assertion_signing_key: str | None,
+    client_assertion_signing_key: str,
     client_assertion_signing_alg: str | None,
 ) -> str:
     """Creates a JWT for the client_assertion field.
@@ -18,7 +18,7 @@ def create_client_assertion_jwt(
     Args:
         domain (str): The domain of your Auth0 tenant
         client_id (str): Your application's client ID
-        client_assertion_signing_key (str, optional): Private key used to sign the client assertion JWT
+        client_assertion_signing_key (str): Private key used to sign the client assertion JWT
         client_assertion_signing_alg (str, optional): Algorithm used to sign the client assertion JWT (defaults to 'RS256')
 
     Returns:

--- a/auth0/authentication/client_authentication.py
+++ b/auth0/authentication/client_authentication.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import datetime
 import uuid
+from typing import Any
 
 import jwt
 
 
 def create_client_assertion_jwt(
-    domain, client_id, client_assertion_signing_key, client_assertion_signing_alg
-):
+    domain: str,
+    client_id: str,
+    client_assertion_signing_key: str | None,
+    client_assertion_signing_alg: str | None,
+) -> str:
     """Creates a JWT for the client_assertion field.
 
     Args:
@@ -35,13 +41,13 @@ def create_client_assertion_jwt(
 
 
 def add_client_authentication(
-    payload,
-    domain,
-    client_id,
-    client_secret,
-    client_assertion_signing_key,
-    client_assertion_signing_alg,
-):
+    payload: dict[str, Any],
+    domain: str,
+    client_id: str,
+    client_secret: str,
+    client_assertion_signing_key: str | None,
+    client_assertion_signing_alg: str | None,
+) -> dict[str, Any]:
     """Adds the client_assertion or client_secret fields to authenticate a payload.
 
     Args:

--- a/auth0/authentication/database.py
+++ b/auth0/authentication/database.py
@@ -24,7 +24,7 @@ class Database(AuthenticationBase):
         name: str | None = None,
         nickname: str | None = None,
         picture: str | None = None,
-    ) -> Any:
+    ) -> dict[str, Any]:
         """Signup using email and password.
 
         Args:
@@ -52,7 +52,7 @@ class Database(AuthenticationBase):
 
         See: https://auth0.com/docs/api/authentication#signup
         """
-        body = {
+        body: dict[str, Any] = {
             "client_id": self.client_id,
             "email": email,
             "password": password,
@@ -73,13 +73,14 @@ class Database(AuthenticationBase):
         if picture:
             body.update({"picture": picture})
 
-        return self.post(
+        data: dict[str, Any] = self.post(
             f"{self.protocol}://{self.domain}/dbconnections/signup", data=body
         )
+        return data
 
     def change_password(
         self, email: str, connection: str, password: str | None = None
-    ) -> Any:
+    ) -> str:
         """Asks to change a password for a given user.
 
         email (str): The user's email address.
@@ -92,7 +93,8 @@ class Database(AuthenticationBase):
             "connection": connection,
         }
 
-        return self.post(
+        data: str = self.post(
             f"{self.protocol}://{self.domain}/dbconnections/change_password",
             data=body,
         )
+        return data

--- a/auth0/authentication/database.py
+++ b/auth0/authentication/database.py
@@ -1,4 +1,6 @@
-import warnings
+from __future__ import annotations
+
+from typing import Any
 
 from .base import AuthenticationBase
 
@@ -12,17 +14,17 @@ class Database(AuthenticationBase):
 
     def signup(
         self,
-        email,
-        password,
-        connection,
-        username=None,
-        user_metadata=None,
-        given_name=None,
-        family_name=None,
-        name=None,
-        nickname=None,
-        picture=None,
-    ):
+        email: str,
+        password: str,
+        connection: str,
+        username: str | None = None,
+        user_metadata: dict[str, Any] | None = None,
+        given_name: str | None = None,
+        family_name: str | None = None,
+        name: str | None = None,
+        nickname: str | None = None,
+        picture: str | None = None,
+    ) -> Any:
         """Signup using email and password.
 
         Args:
@@ -75,7 +77,9 @@ class Database(AuthenticationBase):
             f"{self.protocol}://{self.domain}/dbconnections/signup", data=body
         )
 
-    def change_password(self, email, connection, password=None):
+    def change_password(
+        self, email: str, connection: str, password: str | None = None
+    ) -> Any:
         """Asks to change a password for a given user.
 
         email (str): The user's email address.

--- a/auth0/authentication/delegated.py
+++ b/auth0/authentication/delegated.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from .base import AuthenticationBase
 
 
@@ -10,13 +14,13 @@ class Delegated(AuthenticationBase):
 
     def get_token(
         self,
-        target,
-        api_type,
-        grant_type,
-        id_token=None,
-        refresh_token=None,
-        scope="openid",
-    ):
+        target: str,
+        api_type: str,
+        grant_type: str,
+        id_token: str | None = None,
+        refresh_token: str | None = None,
+        scope: str = "openid",
+    ) -> Any:
         """Obtain a delegation token."""
 
         if id_token and refresh_token:

--- a/auth0/authentication/enterprise.py
+++ b/auth0/authentication/enterprise.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from .base import AuthenticationBase
 
 
@@ -9,7 +11,7 @@ class Enterprise(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: my-domain.us.auth0.com)
     """
 
-    def saml_metadata(self):
+    def saml_metadata(self) -> Any:
         """Get SAML2.0 Metadata."""
 
         return self.get(
@@ -18,7 +20,7 @@ class Enterprise(AuthenticationBase):
             )
         )
 
-    def wsfed_metadata(self):
+    def wsfed_metadata(self) -> Any:
         """Returns the WS-Federation Metadata."""
 
         url = "{}://{}/wsfed/FederationMetadata/2007-06/FederationMetadata.xml"

--- a/auth0/authentication/get_token.py
+++ b/auth0/authentication/get_token.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from typing import Any
+
 from .base import AuthenticationBase
-from .client_authentication import add_client_authentication
 
 
 class GetToken(AuthenticationBase):
@@ -12,10 +15,10 @@ class GetToken(AuthenticationBase):
 
     def authorization_code(
         self,
-        code,
-        redirect_uri,
-        grant_type="authorization_code",
-    ):
+        code: str,
+        redirect_uri: str | None,
+        grant_type: str = "authorization_code",
+    ) -> Any:
         """Authorization code grant
 
         This is the OAuth 2.0 grant that regular web apps utilize in order
@@ -47,11 +50,11 @@ class GetToken(AuthenticationBase):
 
     def authorization_code_pkce(
         self,
-        code_verifier,
-        code,
-        redirect_uri,
-        grant_type="authorization_code",
-    ):
+        code_verifier: str,
+        code: str,
+        redirect_uri: str | None,
+        grant_type: str = "authorization_code",
+    ) -> Any:
         """Authorization code pkce grant
 
         This is the OAuth 2.0 grant that mobile apps utilize in order to access an API.
@@ -86,9 +89,9 @@ class GetToken(AuthenticationBase):
 
     def client_credentials(
         self,
-        audience,
-        grant_type="client_credentials",
-    ):
+        audience: str,
+        grant_type: str = "client_credentials",
+    ) -> Any:
         """Client credentials grant
 
         This is the OAuth 2.0 grant that server processes utilize in
@@ -116,13 +119,13 @@ class GetToken(AuthenticationBase):
 
     def login(
         self,
-        username,
-        password,
-        scope=None,
-        realm=None,
-        audience=None,
-        grant_type="http://auth0.com/oauth/grant-type/password-realm",
-    ):
+        username: str,
+        password: str,
+        scope: str | None = None,
+        realm: str | None = None,
+        audience: str | None = None,
+        grant_type: str = "http://auth0.com/oauth/grant-type/password-realm",
+    ) -> Any:
         """Calls /oauth/token endpoint with password-realm grant type
 
 
@@ -168,10 +171,10 @@ class GetToken(AuthenticationBase):
 
     def refresh_token(
         self,
-        refresh_token,
-        scope="",
-        grant_type="refresh_token",
-    ):
+        refresh_token: str,
+        scope: str = "",
+        grant_type: str = "refresh_token",
+    ) -> Any:
         """Calls /oauth/token endpoint with refresh token grant type
 
         Use this endpoint to refresh an access token, using the refresh token you got during authorization.
@@ -199,7 +202,9 @@ class GetToken(AuthenticationBase):
             },
         )
 
-    def passwordless_login(self, username, otp, realm, scope, audience):
+    def passwordless_login(
+        self, username: str, otp: str, realm: str, scope: str, audience: str
+    ) -> Any:
         """Calls /oauth/token endpoint with http://auth0.com/oauth/grant-type/passwordless/otp grant type
 
         Once the verification code was received, login the user using this endpoint with their

--- a/auth0/authentication/passwordless.py
+++ b/auth0/authentication/passwordless.py
@@ -1,4 +1,6 @@
-import warnings
+from __future__ import annotations
+
+from typing import Any
 
 from .base import AuthenticationBase
 
@@ -11,7 +13,9 @@ class Passwordless(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: my-domain.us.auth0.com)
     """
 
-    def email(self, email, send="link", auth_params=None):
+    def email(
+        self, email: str, send: str = "link", auth_params: dict[str, str] | None = None
+    ) -> Any:
         """Start flow sending an email.
 
         Given the user email address, it will send an email with:
@@ -48,7 +52,7 @@ class Passwordless(AuthenticationBase):
             f"{self.protocol}://{self.domain}/passwordless/start", data=data
         )
 
-    def sms(self, phone_number):
+    def sms(self, phone_number: str) -> Any:
         """Start flow sending an SMS message.
 
         Given the user phone number, it will send an SMS with

--- a/auth0/authentication/passwordless.py
+++ b/auth0/authentication/passwordless.py
@@ -39,7 +39,7 @@ class Passwordless(AuthenticationBase):
             auth_params (dict, optional): Parameters to append or override.
         """
 
-        data = {
+        data: dict[str, Any] = {
             "client_id": self.client_id,
             "connection": "email",
             "email": email,

--- a/auth0/authentication/revoke_token.py
+++ b/auth0/authentication/revoke_token.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from .base import AuthenticationBase
 
 
@@ -8,7 +10,7 @@ class RevokeToken(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: my-domain.us.auth0.com)
     """
 
-    def revoke_refresh_token(self, token):
+    def revoke_refresh_token(self, token: str) -> Any:
         """Revokes a Refresh Token if it has been compromised
 
         Each revocation request invalidates not only the specific token, but all other tokens

--- a/auth0/authentication/social.py
+++ b/auth0/authentication/social.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from .base import AuthenticationBase
 
 
@@ -9,7 +11,7 @@ class Social(AuthenticationBase):
         domain (str): Your auth0 domain (e.g: my-domain.us.auth0.com)
     """
 
-    def login(self, access_token, connection, scope="openid"):
+    def login(self, access_token: str, connection: str, scope: str = "openid") -> Any:
         """Login using a social provider's access token
 
         Given the social provider's access_token and the connection specified,

--- a/auth0/authentication/token_verifier.py
+++ b/auth0/authentication/token_verifier.py
@@ -39,7 +39,7 @@ class SignatureVerifier:
             raise ValueError("algorithm must be specified.")
         self._algorithm = algorithm
 
-    def _fetch_key(self, key_id: str | None = None) -> str | RSAPublicKey:
+    def _fetch_key(self, key_id: str) -> str | RSAPublicKey:
         """Obtains the key associated to the given key id.
         Must be implemented by subclasses.
 
@@ -111,6 +111,8 @@ class SignatureVerifier:
             or the token's signature doesn't match the calculated one.
         """
         kid = self._get_kid(token)
+        if kid is None:
+            kid = ""
         secret_or_certificate = self._fetch_key(key_id=kid)
 
         return self._decode_jwt(token, secret_or_certificate)  # type: ignore[arg-type]
@@ -128,7 +130,7 @@ class SymmetricSignatureVerifier(SignatureVerifier):
         super().__init__(algorithm)
         self._shared_secret = shared_secret
 
-    def _fetch_key(self, key_id: str | None = None) -> str:
+    def _fetch_key(self, key_id: str = "") -> str:
         return self._shared_secret
 
 

--- a/auth0/authentication/token_verifier.py
+++ b/auth0/authentication/token_verifier.py
@@ -241,7 +241,12 @@ class AsymmetricSignatureVerifier(SignatureVerifier):
         cache_ttl (int, optional): The lifetime of the JWK set cache in seconds. Defaults to 600 seconds.
     """
 
-    def __init__(self, jwks_url: str, algorithm: str = "RS256", cache_ttl: int = JwksFetcher.CACHE_TTL) -> None:
+    def __init__(
+        self,
+        jwks_url: str,
+        algorithm: str = "RS256",
+        cache_ttl: int = JwksFetcher.CACHE_TTL,
+    ) -> None:
         super().__init__(algorithm)
         self._fetcher = JwksFetcher(jwks_url, cache_ttl)
 

--- a/auth0/authentication/token_verifier.py
+++ b/auth0/authentication/token_verifier.py
@@ -44,7 +44,7 @@ class SignatureVerifier:
         Must be implemented by subclasses.
 
         Args:
-            key_id (str, optional): The id of the key to fetch.
+            key_id (str): The id of the key to fetch.
 
         Returns:
             the key to use for verifying a cryptographic signature
@@ -250,7 +250,7 @@ class AsymmetricSignatureVerifier(SignatureVerifier):
         super().__init__(algorithm)
         self._fetcher = JwksFetcher(jwks_url, cache_ttl)
 
-    def _fetch_key(self, key_id: str | None = None) -> RSAPublicKey:
+    def _fetch_key(self, key_id: str) -> RSAPublicKey:
         return self._fetcher.get_key(key_id)
 
 

--- a/auth0/authentication/token_verifier.py
+++ b/auth0/authentication/token_verifier.py
@@ -113,7 +113,7 @@ class SignatureVerifier:
         kid = self._get_kid(token)
         secret_or_certificate = self._fetch_key(key_id=kid)
 
-        return self._decode_jwt(token, secret_or_certificate)
+        return self._decode_jwt(token, secret_or_certificate)  # type: ignore[arg-type]
 
 
 class SymmetricSignatureVerifier(SignatureVerifier):
@@ -149,7 +149,7 @@ class JwksFetcher:
 
     def _init_cache(self, cache_ttl: int) -> None:
         self._cache_value: dict[str, RSAPublicKey] = {}
-        self._cache_date = 0
+        self._cache_date = 0.0
         self._cache_ttl = cache_ttl
         self._cache_is_fresh = False
 

--- a/auth0/authentication/token_verifier.py
+++ b/auth0/authentication/token_verifier.py
@@ -1,11 +1,17 @@
 """Token Verifier module"""
+from __future__ import annotations
+
 import json
 import time
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import jwt
 import requests
 
 from auth0.exceptions import TokenValidationError
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 
 class SignatureVerifier:
@@ -16,7 +22,7 @@ class SignatureVerifier:
         algorithm (str): The expected signing algorithm (e.g. RS256).
     """
 
-    DISABLE_JWT_CHECKS = {
+    DISABLE_JWT_CHECKS: ClassVar[dict[str, bool]] = {
         "verify_signature": True,
         "verify_exp": False,
         "verify_nbf": False,
@@ -28,12 +34,12 @@ class SignatureVerifier:
         "require_nbf": False,
     }
 
-    def __init__(self, algorithm):
+    def __init__(self, algorithm: str) -> None:
         if not algorithm or type(algorithm) != str:
             raise ValueError("algorithm must be specified.")
         self._algorithm = algorithm
 
-    def _fetch_key(self, key_id=None):
+    def _fetch_key(self, key_id: str | None = None) -> str | RSAPublicKey:
         """Obtains the key associated to the given key id.
         Must be implemented by subclasses.
 
@@ -45,7 +51,7 @@ class SignatureVerifier:
         """
         raise NotImplementedError
 
-    def _get_kid(self, token):
+    def _get_kid(self, token: str) -> str | None:
         """Gets the key id from the kid claim of the header of the token
 
         Args:
@@ -72,7 +78,7 @@ class SignatureVerifier:
 
         return header.get("kid", None)
 
-    def _decode_jwt(self, token, secret_or_certificate):
+    def _decode_jwt(self, token: str, secret_or_certificate: str) -> dict[str, Any]:
         """Verifies and decodes the given JSON web token with the given public key or shared secret.
 
         Args:
@@ -94,7 +100,7 @@ class SignatureVerifier:
             raise TokenValidationError("Invalid token signature.")
         return decoded
 
-    def verify_signature(self, token):
+    def verify_signature(self, token: str) -> dict[str, Any]:
         """Verifies the signature of the given JSON web token.
 
         Args:
@@ -118,11 +124,11 @@ class SymmetricSignatureVerifier(SignatureVerifier):
         algorithm (str, optional): The expected signing algorithm. Defaults to "HS256".
     """
 
-    def __init__(self, shared_secret, algorithm="HS256"):
+    def __init__(self, shared_secret: str, algorithm: str = "HS256") -> None:
         super().__init__(algorithm)
         self._shared_secret = shared_secret
 
-    def _fetch_key(self, key_id=None):
+    def _fetch_key(self, key_id: str | None = None) -> str:
         return self._shared_secret
 
 
@@ -135,20 +141,19 @@ class JwksFetcher:
         cache_ttl (str, optional): The lifetime of the JWK set cache in seconds. Defaults to 600 seconds.
     """
 
-    CACHE_TTL = 600  # 10 min cache lifetime
+    CACHE_TTL: ClassVar[int] = 600  # 10 min cache lifetime
 
-    def __init__(self, jwks_url, cache_ttl=CACHE_TTL):
+    def __init__(self, jwks_url: str, cache_ttl: int = CACHE_TTL) -> None:
         self._jwks_url = jwks_url
         self._init_cache(cache_ttl)
-        return
 
-    def _init_cache(self, cache_ttl):
-        self._cache_value = {}
+    def _init_cache(self, cache_ttl: int) -> None:
+        self._cache_value: dict[str, RSAPublicKey] = {}
         self._cache_date = 0
         self._cache_ttl = cache_ttl
         self._cache_is_fresh = False
 
-    def _cache_expired(self):
+    def _cache_expired(self) -> bool:
         """Checks if the cache is expired
 
         Returns:
@@ -156,7 +161,7 @@ class JwksFetcher:
         """
         return self._cache_date + self._cache_ttl < time.time()
 
-    def _cache_jwks(self, jwks):
+    def _cache_jwks(self, jwks: dict[str, Any]) -> None:
         """Cache the response of the JWKS request
 
         Args:
@@ -166,7 +171,7 @@ class JwksFetcher:
         self._cache_is_fresh = True
         self._cache_date = time.time()
 
-    def _fetch_jwks(self, force=False):
+    def _fetch_jwks(self, force: bool = False) -> dict[str, RSAPublicKey]:
         """Attempts to obtain the JWK set from the cache, as long as it's still valid.
         When not, it will perform a network request to the jwks_url to obtain a fresh result
         and update the cache value with it.
@@ -178,7 +183,7 @@ class JwksFetcher:
             self._cache_value = {}
             response = requests.get(self._jwks_url)
             if response.ok:
-                jwks = response.json()
+                jwks: dict[str, Any] = response.json()
                 self._cache_jwks(jwks)
             return self._cache_value
 
@@ -186,20 +191,22 @@ class JwksFetcher:
         return self._cache_value
 
     @staticmethod
-    def _parse_jwks(jwks):
+    def _parse_jwks(jwks: dict[str, Any]) -> dict[str, RSAPublicKey]:
         """
         Converts a JWK string representation into a binary certificate in PEM format.
         """
-        keys = {}
+        keys: dict[str, RSAPublicKey] = {}
 
         for key in jwks["keys"]:
             # noinspection PyUnresolvedReferences
             # requirement already includes cryptography -> pyjwt[crypto]
-            rsa_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+            rsa_key: RSAPublicKey = jwt.algorithms.RSAAlgorithm.from_jwk(
+                json.dumps(key)
+            )
             keys[key["kid"]] = rsa_key
         return keys
 
-    def get_key(self, key_id):
+    def get_key(self, key_id: str) -> RSAPublicKey:
         """Obtains the JWK associated with the given key id.
 
         Args:
@@ -232,11 +239,11 @@ class AsymmetricSignatureVerifier(SignatureVerifier):
         cache_ttl (int, optional): The lifetime of the JWK set cache in seconds. Defaults to 600 seconds.
     """
 
-    def __init__(self, jwks_url, algorithm="RS256", cache_ttl=JwksFetcher.CACHE_TTL):
+    def __init__(self, jwks_url: str, algorithm: str = "RS256", cache_ttl: int = JwksFetcher.CACHE_TTL) -> None:
         super().__init__(algorithm)
         self._fetcher = JwksFetcher(jwks_url, cache_ttl)
 
-    def _fetch_key(self, key_id=None):
+    def _fetch_key(self, key_id: str | None = None) -> RSAPublicKey:
         return self._fetcher.get_key(key_id)
 
 
@@ -252,7 +259,13 @@ class TokenVerifier:
         Defaults to 60 seconds.
     """
 
-    def __init__(self, signature_verifier, issuer, audience, leeway=0):
+    def __init__(
+        self,
+        signature_verifier: SignatureVerifier,
+        issuer: str,
+        audience: str,
+        leeway: int = 0,
+    ) -> None:
         if not signature_verifier or not isinstance(
             signature_verifier, SignatureVerifier
         ):
@@ -266,7 +279,13 @@ class TokenVerifier:
         self._sv = signature_verifier
         self._clock = None  # visible for testing
 
-    def verify(self, token, nonce=None, max_age=None, organization=None):
+    def verify(
+        self,
+        token: str,
+        nonce: str | None = None,
+        max_age: int | None = None,
+        organization: str | None = None,
+    ) -> dict[str, Any]:
         """Attempts to verify the given ID token, following the steps defined in the OpenID Connect spec.
 
         Args:
@@ -296,7 +315,13 @@ class TokenVerifier:
 
         return payload
 
-    def _verify_payload(self, payload, nonce=None, max_age=None, organization=None):
+    def _verify_payload(
+        self,
+        payload: dict[str, Any],
+        nonce: str | None = None,
+        max_age: int | None = None,
+        organization: str | None = None,
+    ) -> None:
         # Issuer
         if "iss" not in payload or not isinstance(payload["iss"], str):
             raise TokenValidationError(

--- a/auth0/authentication/users.py
+++ b/auth0/authentication/users.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
+from typing import Any
+
 from auth0.rest import RestClient, RestClientOptions
+from auth0.types import TimeoutType
 
 
 class Users:
@@ -13,11 +18,11 @@ class Users:
 
     def __init__(
         self,
-        domain,
-        telemetry=True,
-        timeout=5.0,
-        protocol="https",
-    ):
+        domain: str,
+        telemetry: bool = True,
+        timeout: TimeoutType = 5.0,
+        protocol: str = "https",
+    ) -> None:
         self.domain = domain
         self.protocol = protocol
         self.client = RestClient(
@@ -31,7 +36,7 @@ class Users:
         domain (str): Your auth0 domain (e.g: username.auth0.com)
     """
 
-    def userinfo(self, access_token):
+    def userinfo(self, access_token: str) -> dict[str, Any]:
         """Returns the user information based on the Auth0 access token.
         This endpoint will work only if openid was granted as a scope for the access_token.
 
@@ -42,7 +47,8 @@ class Users:
             The user profile.
         """
 
-        return self.client.get(
+        data: dict[str, Any] = self.client.get(
             url=f"{self.protocol}://{self.domain}/userinfo",
             headers={"Authorization": f"Bearer {access_token}"},
         )
+        return data

--- a/auth0/exceptions.py
+++ b/auth0/exceptions.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
+
 from typing import Any
 
+
 class Auth0Error(Exception):
-    def __init__(self, status_code: int, error_code: str, message: str, content: Any | None = None) -> None:
+    def __init__(
+        self,
+        status_code: int,
+        error_code: str,
+        message: str,
+        content: Any | None = None,
+    ) -> None:
         self.status_code = status_code
         self.error_code = error_code
         self.message = message

--- a/auth0/exceptions.py
+++ b/auth0/exceptions.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+from typing import Any
+
 class Auth0Error(Exception):
-    def __init__(self, status_code, error_code, message, content=None):
+    def __init__(self, status_code: int, error_code: str, message: str, content: Any | None = None) -> None:
         self.status_code = status_code
         self.error_code = error_code
         self.message = message
         self.content = content
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.status_code}: {self.message}"
 
 
 class RateLimitError(Auth0Error):
-    def __init__(self, error_code, message, reset_at):
+    def __init__(self, error_code: str, message: str, reset_at: int) -> None:
         super().__init__(status_code=429, error_code=error_code, message=message)
         self.reset_at = reset_at
 

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import base64
 import json
 import platform
@@ -36,7 +37,12 @@ class RestClientOptions:
             (defaults to 3)
     """
 
-    def __init__(self, telemetry: bool | None = None, timeout: TimeoutType | None = None, retries: int | None = None) -> None:
+    def __init__(
+        self,
+        telemetry: bool | None = None,
+        timeout: TimeoutType | None = None,
+        retries: int | None = None,
+    ) -> None:
         self.telemetry = True
         self.timeout = 5.0
         self.retries = 3
@@ -69,7 +75,13 @@ class RestClient:
             (defaults to 3)
     """
 
-    def __init__(self, jwt: str, telemetry: bool = True, timeout: TimeoutType = 5.0, options: RestClientOptions | None = None) -> None:
+    def __init__(
+        self,
+        jwt: str,
+        telemetry: bool = True,
+        timeout: TimeoutType = 5.0,
+        options: RestClientOptions | None = None,
+    ) -> None:
         if options is None:
             options = RestClientOptions(telemetry=telemetry, timeout=timeout)
 
@@ -131,7 +143,12 @@ class RestClient:
     def MIN_REQUEST_RETRY_DELAY(self) -> int:
         return 100
 
-    def get(self, url: str, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> Any:
+    def get(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
 
@@ -167,7 +184,12 @@ class RestClient:
         # Return the final Response
         return self._process_response(response)
 
-    def post(self, url: str, data: RequestData | None = None, headers: dict[str, str] | None = None) -> Any:
+    def post(
+        self,
+        url: str,
+        data: RequestData | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
 
@@ -176,7 +198,12 @@ class RestClient:
         )
         return self._process_response(response)
 
-    def file_post(self, url: str, data: RequestData | None = None, files: dict[str, Any] | None = None) -> Any:
+    def file_post(
+        self,
+        url: str,
+        data: RequestData | None = None,
+        files: dict[str, Any] | None = None,
+    ) -> Any:
         headers = self.base_headers.copy()
         headers.pop("Content-Type", None)
 
@@ -201,7 +228,12 @@ class RestClient:
         )
         return self._process_response(response)
 
-    def delete(self, url: str, params: dict[str, Any] | None = None, data: RequestData | None = None) -> Any:
+    def delete(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+        data: RequestData | None = None,
+    ) -> Any:
         headers = self.base_headers.copy()
 
         response = requests.delete(
@@ -247,7 +279,9 @@ class RestClient:
 
 
 class Response:
-    def __init__(self, status_code: int, content: Any, headers: Mapping[str, str]) -> None:
+    def __init__(
+        self, status_code: int, content: Any, headers: Mapping[str, str]
+    ) -> None:
         self._status_code = status_code
         self._content = content
         self._headers = headers

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -255,7 +255,7 @@ class RestClient:
         wait = max(self.MIN_REQUEST_RETRY_DELAY(), wait)
 
         self._metrics["retries"] = attempt
-        self._metrics["backoff"].append(wait)
+        self._metrics["backoff"].append(wait)  # type: ignore[attr-defined]
 
         return wait
 

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -6,13 +6,15 @@ import platform
 import sys
 from random import randint
 from time import sleep
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 import requests
 
 from auth0.exceptions import Auth0Error, RateLimitError
-from auth0.rest_async import RequestsResponse
 from auth0.types import RequestData, TimeoutType
+
+if TYPE_CHECKING:
+    from auth0.rest_async import RequestsResponse
 
 UNKNOWN_ERROR = "a0.sdk.internal.unknown"
 

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -41,29 +41,20 @@ class RestClientOptions:
 
     def __init__(
         self,
-        telemetry: bool | None = None,
-        timeout: TimeoutType | None = None,
-        retries: int | None = None,
+        telemetry: bool = True,
+        timeout: TimeoutType = 5.0,
+        retries: int = 3,
     ) -> None:
-        self.telemetry = True
-        self.timeout = 5.0
-        self.retries = 3
-
-        if telemetry is not None:
-            self.telemetry = telemetry
-
-        if timeout is not None:
-            self.timeout = timeout
-
-        if retries is not None:
-            self.retries = retries
+        self.telemetry = telemetry
+        self.timeout = timeout
+        self.retries = retries
 
 
 class RestClient:
     """Provides simple methods for handling all RESTful api endpoints.
 
     Args:
-        jwt (str): The JWT to be used with the RestClient.
+        jwt (str, optional): The JWT to be used with the RestClient.
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
         timeout (float or tuple, optional): Change the requests
@@ -79,7 +70,7 @@ class RestClient:
 
     def __init__(
         self,
-        jwt: str,
+        jwt: str | None,
         telemetry: bool = True,
         timeout: TimeoutType = 5.0,
         options: RestClientOptions | None = None,

--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
 import base64
 import json
 import platform
 import sys
 from random import randint
 from time import sleep
+from typing import Any, Mapping
 
 import requests
 
 from auth0.exceptions import Auth0Error, RateLimitError
+from auth0.rest_async import RequestsResponse
+from auth0.types import RequestData, TimeoutType
 
 UNKNOWN_ERROR = "a0.sdk.internal.unknown"
 
@@ -32,7 +36,7 @@ class RestClientOptions:
             (defaults to 3)
     """
 
-    def __init__(self, telemetry=None, timeout=None, retries=None):
+    def __init__(self, telemetry: bool | None = None, timeout: TimeoutType | None = None, retries: int | None = None) -> None:
         self.telemetry = True
         self.timeout = 5.0
         self.retries = 3
@@ -51,6 +55,7 @@ class RestClient:
     """Provides simple methods for handling all RESTful api endpoints.
 
     Args:
+        jwt (str): The JWT to be used with the RestClient.
         telemetry (bool, optional): Enable or disable Telemetry
             (defaults to True)
         timeout (float or tuple, optional): Change the requests
@@ -64,7 +69,7 @@ class RestClient:
             (defaults to 3)
     """
 
-    def __init__(self, jwt, telemetry=True, timeout=5.0, options=None):
+    def __init__(self, jwt: str, telemetry: bool = True, timeout: TimeoutType = 5.0, options: RestClientOptions | None = None) -> None:
         if options is None:
             options = RestClientOptions(telemetry=telemetry, timeout=timeout)
 
@@ -111,22 +116,22 @@ class RestClient:
         self.timeout = options.timeout
 
     # Returns a hard cap for the maximum number of retries allowed (10)
-    def MAX_REQUEST_RETRIES(self):
+    def MAX_REQUEST_RETRIES(self) -> int:
         return 10
 
     # Returns the maximum amount of jitter to introduce in milliseconds (100ms)
-    def MAX_REQUEST_RETRY_JITTER(self):
+    def MAX_REQUEST_RETRY_JITTER(self) -> int:
         return 100
 
     # Returns the maximum delay window allowed (1000ms)
-    def MAX_REQUEST_RETRY_DELAY(self):
+    def MAX_REQUEST_RETRY_DELAY(self) -> int:
         return 1000
 
     # Returns the minimum delay window allowed (100ms)
-    def MIN_REQUEST_RETRY_DELAY(self):
+    def MIN_REQUEST_RETRY_DELAY(self) -> int:
         return 100
 
-    def get(self, url, params=None, headers=None):
+    def get(self, url: str, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> Any:
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
 
@@ -162,7 +167,7 @@ class RestClient:
         # Return the final Response
         return self._process_response(response)
 
-    def post(self, url, data=None, headers=None):
+    def post(self, url: str, data: RequestData | None = None, headers: dict[str, str] | None = None) -> Any:
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
 
@@ -171,7 +176,7 @@ class RestClient:
         )
         return self._process_response(response)
 
-    def file_post(self, url, data=None, files=None):
+    def file_post(self, url: str, data: RequestData | None = None, files: dict[str, Any] | None = None) -> Any:
         headers = self.base_headers.copy()
         headers.pop("Content-Type", None)
 
@@ -180,7 +185,7 @@ class RestClient:
         )
         return self._process_response(response)
 
-    def patch(self, url, data=None):
+    def patch(self, url: str, data: RequestData | None = None) -> Any:
         headers = self.base_headers.copy()
 
         response = requests.patch(
@@ -188,7 +193,7 @@ class RestClient:
         )
         return self._process_response(response)
 
-    def put(self, url, data=None):
+    def put(self, url: str, data: RequestData | None = None) -> Any:
         headers = self.base_headers.copy()
 
         response = requests.put(
@@ -196,7 +201,7 @@ class RestClient:
         )
         return self._process_response(response)
 
-    def delete(self, url, params=None, data=None):
+    def delete(self, url: str, params: dict[str, Any] | None = None, data: RequestData | None = None) -> Any:
         headers = self.base_headers.copy()
 
         response = requests.delete(
@@ -208,7 +213,7 @@ class RestClient:
         )
         return self._process_response(response)
 
-    def _calculate_wait(self, attempt):
+    def _calculate_wait(self, attempt: int) -> int:
         # Retry the request. Apply a exponential backoff for subsequent attempts, using this formula:
         # max(MIN_REQUEST_RETRY_DELAY, min(MAX_REQUEST_RETRY_DELAY, (100ms * (2 ** attempt - 1)) + random_between(1, MAX_REQUEST_RETRY_JITTER)))
 
@@ -229,10 +234,10 @@ class RestClient:
 
         return wait
 
-    def _process_response(self, response):
+    def _process_response(self, response: requests.Response) -> Any:
         return self._parse(response).content()
 
-    def _parse(self, response):
+    def _parse(self, response: requests.Response) -> Response:
         if not response.text:
             return EmptyResponse(response.status_code)
         try:
@@ -242,12 +247,12 @@ class RestClient:
 
 
 class Response:
-    def __init__(self, status_code, content, headers):
+    def __init__(self, status_code: int, content: Any, headers: Mapping[str, str]) -> None:
         self._status_code = status_code
         self._content = content
         self._headers = headers
 
-    def content(self):
+    def content(self) -> Any:
         if self._is_error():
             if self._status_code == 429:
                 reset_at = int(self._headers.get("x-ratelimit-reset", "-1"))
@@ -272,7 +277,7 @@ class Response:
         else:
             return self._content
 
-    def _is_error(self):
+    def _is_error(self) -> bool:
         return self._status_code is None or self._status_code >= 400
 
     # Adding these methods to force implementation in subclasses because they are references in this parent class
@@ -284,11 +289,11 @@ class Response:
 
 
 class JsonResponse(Response):
-    def __init__(self, response):
+    def __init__(self, response: requests.Response | RequestsResponse) -> None:
         content = json.loads(response.text)
         super().__init__(response.status_code, content, response.headers)
 
-    def _error_code(self):
+    def _error_code(self) -> str:
         if "errorCode" in self._content:
             return self._content.get("errorCode")
         elif "error" in self._content:
@@ -298,7 +303,7 @@ class JsonResponse(Response):
         else:
             return UNKNOWN_ERROR
 
-    def _error_message(self):
+    def _error_message(self) -> str:
         if "error_description" in self._content:
             return self._content.get("error_description")
         message = self._content.get("message", "")
@@ -308,22 +313,22 @@ class JsonResponse(Response):
 
 
 class PlainResponse(Response):
-    def __init__(self, response):
+    def __init__(self, response: requests.Response | RequestsResponse) -> None:
         super().__init__(response.status_code, response.text, response.headers)
 
-    def _error_code(self):
+    def _error_code(self) -> str:
         return UNKNOWN_ERROR
 
-    def _error_message(self):
+    def _error_message(self) -> str:
         return self._content
 
 
 class EmptyResponse(Response):
-    def __init__(self, status_code):
+    def __init__(self, status_code: int) -> None:
         super().__init__(status_code, "", {})
 
-    def _error_code(self):
+    def _error_code(self) -> str:
         return UNKNOWN_ERROR
 
-    def _error_message(self):
+    def _error_message(self) -> str:
         return ""

--- a/auth0/rest_async.py
+++ b/auth0/rest_async.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import asyncio
 from typing import Any
 
@@ -7,7 +8,7 @@ import aiohttp
 from auth0.exceptions import RateLimitError
 from auth0.types import RequestData
 
-from .rest import Response, EmptyResponse, JsonResponse, PlainResponse, RestClient
+from .rest import EmptyResponse, JsonResponse, PlainResponse, Response, RestClient
 
 
 def _clean_params(params: dict[Any, Any] | None) -> dict[Any, Any] | None:
@@ -64,7 +65,12 @@ class AsyncRestClient(RestClient):
                 async with session.request(*args, **kwargs) as response:
                     return await self._process_response(response)
 
-    async def get(self, url: str, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> Any:
+    async def get(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
         # Track the API request attempt number
@@ -95,12 +101,22 @@ class AsyncRestClient(RestClient):
                 # sleep() functions in seconds, so convert the milliseconds formula above accordingly
                 await asyncio.sleep(wait / 1000)
 
-    async def post(self, url: str, data: RequestData | None = None, headers: dict[str, str] | None = None) -> Any:
+    async def post(
+        self,
+        url: str,
+        data: RequestData | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
         request_headers = self.base_headers.copy()
         request_headers.update(headers or {})
         return await self._request("post", url, json=data, headers=request_headers)
 
-    async def file_post(self, url: str, data: dict[str, Any] | None = None, files: dict[str, Any] | None = None) -> Any:
+    async def file_post(
+        self,
+        url: str,
+        data: dict[str, Any] | None = None,
+        files: dict[str, Any] | None = None,
+    ) -> Any:
         headers = self.base_headers.copy()
         headers.pop("Content-Type", None)
         return await self._request("post", url, data={**data, **files}, headers=headers)
@@ -111,7 +127,12 @@ class AsyncRestClient(RestClient):
     async def put(self, url: str, data: RequestData | None = None) -> Any:
         return await self._request("put", url, json=data)
 
-    async def delete(self, url: str, params: dict[str, Any] | None = None, data: RequestData | None = None) -> Any:
+    async def delete(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+        data: RequestData | None = None,
+    ) -> Any:
         return await self._request(
             "delete", url, json=data, params=_clean_params(params) or {}
         )

--- a/auth0/rest_async.py
+++ b/auth0/rest_async.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code=override
 from __future__ import annotations
 
 import asyncio
@@ -36,7 +37,7 @@ class AsyncRestClient(RestClient):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._session = None
+        self._session: aiohttp.ClientSession | None = None
         sock_connect, sock_read = (
             self.timeout
             if isinstance(self.timeout, tuple)

--- a/auth0/rest_async.py
+++ b/auth0/rest_async.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code=override
 from __future__ import annotations
 
 import asyncio
@@ -115,8 +114,8 @@ class AsyncRestClient(RestClient):
     async def file_post(
         self,
         url: str,
-        data: dict[str, Any] | None = None,
-        files: dict[str, Any] | None = None,
+        data: dict[str, Any],
+        files: dict[str, Any],
     ) -> Any:
         headers = self.base_headers.copy()
         headers.pop("Content-Type", None)

--- a/auth0/types.py
+++ b/auth0/types.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
+from typing import Any, Dict, List, Tuple, Union
 
-from typing import Any
+TimeoutType = Union[float, Tuple[float, float]]
 
-TimeoutType = float | tuple[float, float]
-
-RequestData = dict[str, Any] | list[Any]
+RequestData = Union[Dict[str, Any], List[Any]]

--- a/auth0/types.py
+++ b/auth0/types.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Any
 
 TimeoutType = float | tuple[float, float]

--- a/auth0/types.py
+++ b/auth0/types.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+from typing import Any
+
+TimeoutType = float | tuple[float, float]
+
+RequestData = dict[str, Any] | list[Any]

--- a/auth0/utils.py
+++ b/auth0/utils.py
@@ -1,4 +1,4 @@
-def is_async_available():
+def is_async_available() -> bool:
     try:
         import asyncio
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,3 +93,6 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
+
+# Sphinx somehow can't find this one
+nitpick_ignore = [("py:class", "RSAPublicKey")]

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,9 @@ ignore_errors = True
 
 [mypy-auth0.management.*]
 ignore_errors = True
+
+[mypy-auth0.rest_async]
+disable_error_code=override
+
+[mypy-auth0.authentication.async_token_verifier]
+disable_error_code=override, misc, attr-defined

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.7
+
+[mypy-auth0.test.*,auth0.test_async.*]
+ignore_errors = True
+
+[mypy-auth0.management.*]
+ignore_errors = True


### PR DESCRIPTION
Fixes partially #470.
The goal is not to add complete type hints to the library, but only were it is beneficial. There are some code patterns that break mypy rules (e.g.  Liskov substitution principle), and I'm not aiming at doing refactors, so once most of the type hints will be added, I'll write a mypy configuration accordingly.

I'm going for the `from __future import annotations` import, to improve type hints readability.

Noticed a couple things:

- This has been introduced two years ago, should it be deprecated now?
https://github.com/auth0/auth0-python/blob/44d6d0ec5c0a098a6d333e7f24d784416da07bca/auth0/rest.py#L108-L111

- Could these methods be transformed into properties/class variables?
https://github.com/auth0/auth0-python/blob/44d6d0ec5c0a098a6d333e7f24d784416da07bca/auth0/rest.py#L113-L127