### PR TITLE
Add branding theme endpoints

### DIFF
--- a/auth0/management/branding.py
+++ b/auth0/management/branding.py
@@ -93,3 +93,56 @@ class Branding:
             self._url("templates", "universal-login"),
             body={"template": body},
         )
+
+    def get_default_branding_theme(self):
+        """Retrieve default branding theme.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/get_default_branding_theme
+        """
+
+        return self.client.get(self._url("themes", "default"))
+
+    def get_branding_theme(self, theme_id):
+        """Retrieve branding theme.
+
+        Args:
+            theme_id (str): The theme_id to retrieve branding theme for.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/get_branding_theme
+        """
+
+        return self.client.get(self._url("themes", theme_id))
+
+    def delete_branding_theme(self, theme_id):
+        """Delete branding theme.
+
+        Args:
+            theme_id (str): The theme_id to delete branding theme for.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/delete_branding_theme
+        """
+
+        return self.client.delete(self._url("themes", theme_id))
+
+    def update_branding_theme(self, theme_id, body):
+        """Update branding theme.
+
+        Args:
+            theme_id (str): The theme_id to update branding theme for.
+            body (dict): The attributes to set on the theme.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/patch_branding_theme
+        """
+
+        return self.client.patch(self._url("themes", theme_id), data=body)
+
+    def create_branding_theme(self, body):
+        """Create branding theme.
+
+        Args:
+            body (dict): The attributes to set on the theme.
+
+        See: https://auth0.com/docs/api/management/v2#!/Branding/post_branding_theme
+        """
+
+        return self.client.post(self._url("themes"), data=body)

--- a/auth0/test/management/test_branding.py
+++ b/auth0/test/management/test_branding.py
@@ -71,3 +71,65 @@ class TestBranding(unittest.TestCase):
             "https://domain/api/v2/branding/templates/universal-login",
             body={"template": {"a": "b", "c": "d"}},
         )
+
+    @mock.patch("auth0.management.branding.RestClient")
+    def test_get_default_branding_theme(self, mock_rc):
+        api = mock_rc.return_value
+        api.get.return_value = {}
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.get_default_branding_theme()
+
+        api.get.assert_called_with(
+            "https://domain/api/v2/branding/themes/default",
+        )
+
+    @mock.patch("auth0.management.branding.RestClient")
+    def test_get_branding_theme(self, mock_rc):
+        api = mock_rc.return_value
+        api.get.return_value = {}
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.get_branding_theme("theme_id")
+
+        api.get.assert_called_with(
+            "https://domain/api/v2/branding/themes/theme_id",
+        )
+
+    @mock.patch("auth0.management.branding.RestClient")
+    def test_delete_branding_theme(self, mock_rc):
+        api = mock_rc.return_value
+        api.delete.return_value = {}
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.delete_branding_theme("theme_id")
+
+        api.delete.assert_called_with(
+            "https://domain/api/v2/branding/themes/theme_id",
+        )
+
+    @mock.patch("auth0.management.branding.RestClient")
+    def test_update_branding_theme(self, mock_rc):
+        api = mock_rc.return_value
+        api.patch.return_value = {}
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.update_branding_theme("theme_id", {})
+
+        api.patch.assert_called_with(
+            "https://domain/api/v2/branding/themes/theme_id",
+            data={},
+        )
+
+    @mock.patch("auth0.management.branding.RestClient")
+    def test_create_branding_theme(self, mock_rc):
+        api = mock_rc.return_value
+        api.post.return_value = {}
+
+        branding = Branding(domain="domain", token="jwttoken")
+        branding.create_branding_theme({})
+
+        api.post.assert_called_with(
+            "https://domain/api/v2/branding/themes",
+            data={},
+        )


### PR DESCRIPTION
### Changes

Adding:

https://auth0.com/docs/api/management/v2#!/Branding/get_default_branding_theme
https://auth0.com/docs/api/management/v2#!/Branding/get_branding_theme
https://auth0.com/docs/api/management/v2#!/Branding/delete_branding_theme
https://auth0.com/docs/api/management/v2#!/Branding/patch_branding_theme
https://auth0.com/docs/api/management/v2#!/Branding/post_branding_theme

### References

fixes #475 