### PR TITLE
Make pw realm params optional

### DIFF
--- a/auth0/authentication/get_token.py
+++ b/auth0/authentication/get_token.py
@@ -118,9 +118,9 @@ class GetToken(AuthenticationBase):
         self,
         username,
         password,
-        scope,
-        realm,
-        audience,
+        scope=None,
+        realm=None,
+        audience=None,
         grant_type="http://auth0.com/oauth/grant-type/password-realm",
     ):
         """Calls /oauth/token endpoint with password-realm grant type
@@ -134,17 +134,17 @@ class GetToken(AuthenticationBase):
         this information.
 
         Args:
-            audience (str): The unique identifier of the target API you want to access.
-
             username (str): Resource owner's identifier
 
             password (str): resource owner's Secret
 
-            scope(str): String value of the different scopes the client is asking for.
+            scope(str, optional): String value of the different scopes the client is asking for.
             Multiple scopes are separated with whitespace.
 
-            realm (str): String value of the realm the user belongs.
+            realm (str, optional): String value of the realm the user belongs.
             Set this if you want to add realm support at this grant.
+
+            audience (str, optional): The unique identifier of the target API you want to access.
 
             grant_type (str, optional): Denotes the flow you're using. For password realm
             use http://auth0.com/oauth/grant-type/password-realm

--- a/auth0/test/authentication/test_get_token.py
+++ b/auth0/test/authentication/test_get_token.py
@@ -164,6 +164,32 @@ class TestGetToken(unittest.TestCase):
         )
 
     @mock.patch("auth0.rest.RestClient.post")
+    def test_login_simple(self, mock_post):
+        g = GetToken("my.domain.com", "cid", client_secret="clsec")
+
+        g.login(
+            username="usrnm",
+            password="pswd",
+        )
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], "https://my.domain.com/oauth/token")
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "client_id": "cid",
+                "client_secret": "clsec",
+                "username": "usrnm",
+                "password": "pswd",
+                "realm": None,
+                "scope": None,
+                "audience": None,
+                "grant_type": "http://auth0.com/oauth/grant-type/password-realm",
+            },
+        )
+
+    @mock.patch("auth0.rest.RestClient.post")
     def test_refresh_token(self, mock_post):
         g = GetToken("my.domain.com", "cid", client_secret="clsec")
 


### PR DESCRIPTION
### Changes

Change `scope`, `realm` and `audience` arguments to keyword args, since these parameters are optional: http://auth0.com/oauth/grant-type/password-realm

### References

Fixes #482
