### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.2.0](https://github.com/auth0/auth0-python/tree/4.2.0) (2023-05-02)
+[Full Changelog](https://github.com/auth0/auth0-python/compare/4.1.1...4.2.0)
+
+**Added**
+- Add cache_ttl param to AsymmetricSignatureVerifier [\#490](https://github.com/auth0/auth0-python/pull/490) ([matei-radu](https://github.com/matei-radu))
+
 ## [4.1.1](https://github.com/auth0/auth0-python/tree/4.1.1) (2023-04-13)
 [Full Changelog](https://github.com/auth0/auth0-python/compare/4.1.0...4.1.1)
 

--- a/auth0/__init__.py
+++ b/auth0/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.1.1"
+__version__ = "4.2.0"
 
 from auth0.exceptions import Auth0Error, RateLimitError, TokenValidationError
 


### PR DESCRIPTION

**Added**
- Add cache_ttl param to AsymmetricSignatureVerifier [\#490](https://github.com/auth0/auth0-python/pull/490) ([matei-radu](https://github.com/matei-radu))
