### PR TITLE
Fix async auth client

### DIFF
--- a/auth0/asyncify.py
+++ b/auth0/asyncify.py
@@ -1,6 +1,8 @@
 import aiohttp
 
+from auth0.rest import RestClientOptions
 from auth0.rest_async import AsyncRestClient
+from auth0.authentication.base import AuthenticationBase
 
 
 def _gen_async(client, method):
@@ -19,7 +21,7 @@ def asyncify(cls):
         if callable(getattr(cls, func)) and not func.startswith("_")
     ]
 
-    class AsyncClient(cls):
+    class AsyncManagementClient(cls):
         def __init__(
             self,
             domain,
@@ -29,40 +31,47 @@ def asyncify(cls):
             protocol="https",
             rest_options=None,
         ):
-            if token is None:
-                # Wrap the auth client
-                super().__init__(domain, telemetry, timeout, protocol)
-            else:
-                # Wrap the mngtmt client
-                super().__init__(
-                    domain, token, telemetry, timeout, protocol, rest_options
-                )
+            super().__init__(domain, token, telemetry, timeout, protocol, rest_options)
             self.client = AsyncRestClient(
                 jwt=token, telemetry=telemetry, timeout=timeout, options=rest_options
             )
 
-    class Wrapper(cls):
+    class AsyncAuthenticationClient(cls):
         def __init__(
             self,
             domain,
-            token=None,
+            client_id,
+            client_secret=None,
+            client_assertion_signing_key=None,
+            client_assertion_signing_alg=None,
             telemetry=True,
             timeout=5.0,
             protocol="https",
-            rest_options=None,
         ):
-            if token is None:
-                # Wrap the auth client
-                super().__init__(domain, telemetry, timeout, protocol)
-            else:
-                # Wrap the mngtmt client
-                super().__init__(
-                    domain, token, telemetry, timeout, protocol, rest_options
-                )
-
-            self._async_client = AsyncClient(
-                domain, token, telemetry, timeout, protocol, rest_options
+            super().__init__(
+                domain,
+                client_id,
+                client_secret,
+                client_assertion_signing_key,
+                client_assertion_signing_alg,
+                telemetry,
+                timeout,
+                protocol,
             )
+            self.client = AsyncRestClient(
+                None,
+                options=RestClientOptions(
+                    telemetry=telemetry, timeout=timeout, retries=0
+                ),
+            )
+
+    class Wrapper(cls):
+        def __init__(self, *args, **kwargs):
+            super(Wrapper, self).__init__(*args, **kwargs)
+            if AuthenticationBase in cls.__bases__:
+                self._async_client = AsyncAuthenticationClient(*args, **kwargs)
+            else:
+                self._async_client = AsyncManagementClient(*args, **kwargs)
             for method in methods:
                 setattr(
                     self,

--- a/auth0/asyncify.py
+++ b/auth0/asyncify.py
@@ -1,8 +1,8 @@
 import aiohttp
 
+from auth0.authentication.base import AuthenticationBase
 from auth0.rest import RestClientOptions
 from auth0.rest_async import AsyncRestClient
-from auth0.authentication.base import AuthenticationBase
 
 
 def _gen_async(client, method):
@@ -67,7 +67,7 @@ def asyncify(cls):
 
     class Wrapper(cls):
         def __init__(self, *args, **kwargs):
-            super(Wrapper, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             if AuthenticationBase in cls.__bases__:
                 self._async_client = AsyncAuthenticationClient(*args, **kwargs)
             else:

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -13,8 +13,10 @@ from callee import Attrs
 
 from auth0.asyncify import asyncify
 from auth0.management import Clients, Guardian, Jobs
+from auth0.authentication import GetToken
 
 clients = re.compile(r"^https://example\.com/api/v2/clients.*")
+token = re.compile(r"^https://example\.com/oauth/token.*")
 factors = re.compile(r"^https://example\.com/api/v2/guardian/factors.*")
 users_imports = re.compile(r"^https://example\.com/api/v2/jobs/users-imports.*")
 payload = {"foo": "bar"}
@@ -81,6 +83,32 @@ class TestAsyncify(getattr(unittest, "IsolatedAsyncioTestCase", object)):
             allow_redirects=True,
             json=data,
             headers=headers,
+            timeout=ANY,
+        )
+
+    @aioresponses()
+    async def test_post_auth(self, mocked):
+        callback, mock = get_callback()
+        mocked.post(token, callback=callback)
+        c = asyncify(GetToken)("example.com", "cid", client_secret="clsec")
+        g = GetToken("my.domain.com", "cid", client_secret="clsec")
+        self.assertEqual(
+            await c.login_async(username="usrnm", password="pswd"), payload
+        )
+        mock.assert_called_with(
+            Attrs(path="/oauth/token"),
+            allow_redirects=True,
+            json={
+                "client_id": "cid",
+                "username": "usrnm",
+                "password": "pswd",
+                "realm": None,
+                "scope": None,
+                "audience": None,
+                "grant_type": "http://auth0.com/oauth/grant-type/password-realm",
+                "client_secret": "clsec",
+            },
+            headers={i: headers[i] for i in headers if i != "Authorization"},
             timeout=ANY,
         )
 

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -12,8 +12,8 @@ from aioresponses import CallbackResult, aioresponses
 from callee import Attrs
 
 from auth0.asyncify import asyncify
-from auth0.management import Clients, Guardian, Jobs
 from auth0.authentication import GetToken
+from auth0.management import Clients, Guardian, Jobs
 
 clients = re.compile(r"^https://example\.com/api/v2/clients.*")
 token = re.compile(r"^https://example\.com/oauth/token.*")
@@ -91,7 +91,6 @@ class TestAsyncify(getattr(unittest, "IsolatedAsyncioTestCase", object)):
         callback, mock = get_callback()
         mocked.post(token, callback=callback)
         c = asyncify(GetToken)("example.com", "cid", client_secret="clsec")
-        g = GetToken("my.domain.com", "cid", client_secret="clsec")
         self.assertEqual(
             await c.login_async(username="usrnm", password="pswd"), payload
         )


### PR DESCRIPTION
### Changes

Asyncifying authentication classes doesn't work because the asyncify method was assuming the wrong signature.

### References

fixes #498 

### Testing

```py
AsyncGetToken = asyncify(GetToken)

get_token = AsyncGetToken(domain, client_id)

response = await self.get_token.login_async(
    username=username,
    password=password,
    realm="Username-Password-Authentication",
    scope="openid profile email",
)
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
