### PR TITLE
Add connections.all name parameter

### DIFF
--- a/auth0/management/connections.py
+++ b/auth0/management/connections.py
@@ -52,6 +52,7 @@ class Connections:
         page=None,
         per_page=None,
         extra_params=None,
+        name=None,
     ):
         """Retrieves all connections.
 
@@ -76,6 +77,8 @@ class Connections:
              the request. The fields, include_fields, page and per_page values
              specified as parameters take precedence over the ones defined here.
 
+           name (str): Provide the name of the connection to retrieve.
+
         See: https://auth0.com/docs/api/management/v2#!/Connections/get_connections
 
         Returns:
@@ -88,6 +91,7 @@ class Connections:
         params["include_fields"] = str(include_fields).lower()
         params["page"] = page
         params["per_page"] = per_page
+        params["name"] = name
 
         return self.client.get(self._url(), params=params)
 

--- a/auth0/test/management/test_connections.py
+++ b/auth0/test/management/test_connections.py
@@ -33,6 +33,7 @@ class TestConnection(unittest.TestCase):
                 "page": None,
                 "per_page": None,
                 "include_fields": "true",
+                "name": None,
             },
         )
 
@@ -50,6 +51,7 @@ class TestConnection(unittest.TestCase):
                 "page": None,
                 "per_page": None,
                 "include_fields": "false",
+                "name": None,
             },
         )
 
@@ -67,6 +69,7 @@ class TestConnection(unittest.TestCase):
                 "page": None,
                 "per_page": None,
                 "include_fields": "true",
+                "name": None,
             },
         )
 
@@ -84,6 +87,7 @@ class TestConnection(unittest.TestCase):
                 "page": 7,
                 "per_page": 25,
                 "include_fields": "true",
+                "name": None,
             },
         )
 
@@ -102,6 +106,25 @@ class TestConnection(unittest.TestCase):
                 "per_page": None,
                 "include_fields": "true",
                 "some_key": "some_value",
+                "name": None,
+            },
+        )
+
+        # Name
+        c.all(name="foo")
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual("https://domain/api/v2/connections", args[0])
+        self.assertEqual(
+            kwargs["params"],
+            {
+                "fields": None,
+                "strategy": None,
+                "page": None,
+                "per_page": None,
+                "include_fields": "true",
+                "name": "foo",
             },
         )
 


### PR DESCRIPTION
### Changes

Add option to pass `name` parameter to `Connections.all` endpoint https://auth0.com/docs/api/management/beta/v2/get-all-connections

### References

fixes #496 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
