### PR TITLE
Add forwardedFor option to password grant login

### DIFF
--- a/auth0/authentication/get_token.py
+++ b/auth0/authentication/get_token.py
@@ -125,6 +125,7 @@ class GetToken(AuthenticationBase):
         realm: str | None = None,
         audience: str | None = None,
         grant_type: str = "http://auth0.com/oauth/grant-type/password-realm",
+        forwarded_for: str | None = None,
     ) -> Any:
         """Calls /oauth/token endpoint with password-realm grant type
 
@@ -152,9 +153,16 @@ class GetToken(AuthenticationBase):
             grant_type (str, optional): Denotes the flow you're using. For password realm
             use http://auth0.com/oauth/grant-type/password-realm
 
+            forwarded_for (str, optional): End-user IP as a string value. Set this if you want
+            brute-force protection to work in server-side scenarios.
+            See https://auth0.com/docs/get-started/authentication-and-authorization-flow/avoid-common-issues-with-resource-owner-password-flow-and-attack-protection
+
         Returns:
             access_token, id_token
         """
+        headers = None
+        if forwarded_for:
+            headers = {"auth0-forwarded-for": forwarded_for}
 
         return self.authenticated_post(
             f"{self.protocol}://{self.domain}/oauth/token",
@@ -167,6 +175,7 @@ class GetToken(AuthenticationBase):
                 "audience": audience,
                 "grant_type": grant_type,
             },
+            headers=headers,
         )
 
     def refresh_token(

--- a/auth0/test/authentication/test_get_token.py
+++ b/auth0/test/authentication/test_get_token.py
@@ -190,6 +190,22 @@ class TestGetToken(unittest.TestCase):
         )
 
     @mock.patch("auth0.rest.RestClient.post")
+    def test_login_with_forwarded_for(self, mock_post):
+        g = GetToken("my.domain.com", "cid", client_secret="clsec")
+
+        g.login(username="usrnm", password="pswd", forwarded_for="192.168.0.1")
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], "https://my.domain.com/oauth/token")
+        self.assertEqual(
+            kwargs["headers"],
+            {
+                "auth0-forwarded-for": "192.168.0.1",
+            },
+        )
+
+    @mock.patch("auth0.rest.RestClient.post")
     def test_refresh_token(self, mock_post):
         g = GetToken("my.domain.com", "cid", client_secret="clsec")
 


### PR DESCRIPTION
### Changes

Add option to pass `auth0-forwarded-for` for the password grant. (the only other grant that advertises using this is the [token exchange](https://auth0.com/docs/api/authentication#token-exchange-for-native-social) endpoint, but we don't support that)

### References

fixes #240 

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
