### PR TITLE
Fix docs publishing

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx
+sphinx_rtd_theme
+sphinx_mdinclude

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -e .
+-r docs/requirements.txt
 aiohttp
 aioresponses
 black
@@ -15,7 +16,4 @@ pytest
 pytest-mock
 pyupgrade
 requests
-Sphinx
-sphinx_rtd_theme
-sphinx_mdinclude
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
### Changes

Fix docs publishing. [Read the docs needs to install sphinx](https://github.com/auth0/auth0-python/blob/master/.readthedocs.yaml#L9) from `docs/requirements.txt`

<img width="832" alt="image" src="https://github.com/auth0/auth0-python/assets/1299658/37c6b4bd-a6cb-45a0-8e3c-6b223cfb2fa7">

### References

fixes #503 
