### PR TITLE
Fix docs pt 2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,4 +6,4 @@ sphinx:
 python:
   version: "3.7"
   install:
-    - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-Sphinx
-sphinx_rtd_theme
-sphinx_mdinclude

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -e .
--r docs/requirements.txt
 aiohttp
 aioresponses
 black
@@ -16,4 +15,7 @@ pytest
 pytest-mock
 pyupgrade
 requests
+Sphinx
+sphinx_rtd_theme
+sphinx_mdinclude
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
### Changes

It seems that Sphinx needs the pyjwt dependency when publishing

### References

<img width="1026" alt="image" src="https://github.com/auth0/auth0-python/assets/1299658/374f12dd-0897-4ec8-b9ce-a259ad4bfd88">

See #503 