### PR TITLE
Remove return types for paginated endpoints

### DIFF
--- a/auth0/management/client_grants.py
+++ b/auth0/management/client_grants.py
@@ -59,7 +59,7 @@ class ClientGrants:
         per_page: int | None = None,
         include_totals: bool = False,
         client_id: str | None = None,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves all client grants.
 
         Args:

--- a/auth0/management/device_credentials.py
+++ b/auth0/management/device_credentials.py
@@ -62,7 +62,7 @@ class DeviceCredentials:
         page: int | None = None,
         per_page: int | None = None,
         include_totals: bool = False,
-    ) -> list[dict[str, Any]]:
+    ):
         """List device credentials.
 
         Args:

--- a/auth0/management/grants.py
+++ b/auth0/management/grants.py
@@ -58,7 +58,7 @@ class Grants:
         per_page: int | None = None,
         include_totals: bool = False,
         extra_params: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves all grants.
 
         Args:

--- a/auth0/management/hooks.py
+++ b/auth0/management/hooks.py
@@ -61,7 +61,7 @@ class Hooks:
         page: int | None = None,
         per_page: int | None = None,
         include_totals: bool = False,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves a list of all hooks.
 
         Args:

--- a/auth0/management/logs.py
+++ b/auth0/management/logs.py
@@ -63,7 +63,7 @@ class Logs:
         from_param: str | None = None,
         take: int | None = None,
         include_fields: bool = True,
-    ) -> list[dict[str, Any]]:
+    ):
         """Search log events.
 
         Args:

--- a/auth0/management/organizations.py
+++ b/auth0/management/organizations.py
@@ -61,7 +61,7 @@ class Organizations:
         include_totals: bool = True,
         from_param: str | None = None,
         take: int | None = None,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves a list of all the organizations.
 
         Args:
@@ -246,7 +246,7 @@ class Organizations:
         include_totals: bool = True,
         from_param: str | None = None,
         take: int | None = None,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves a list of all the organization members.
 
         Args:
@@ -377,7 +377,7 @@ class Organizations:
         page: int | None = None,
         per_page: int | None = None,
         include_totals: bool = False,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves a list of all the organization invitations.
 
         Args:

--- a/auth0/management/resource_servers.py
+++ b/auth0/management/resource_servers.py
@@ -68,7 +68,7 @@ class ResourceServers:
         page: int | None = None,
         per_page: int | None = None,
         include_totals: bool = False,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves all resource servers
 
         Args:

--- a/auth0/management/roles.py
+++ b/auth0/management/roles.py
@@ -58,7 +58,7 @@ class Roles:
         per_page: int = 25,
         include_totals: bool = True,
         name_filter: str | None = None,
-    ) -> List[dict[str, Any]]:
+    ):
         """List or search roles.
 
         Args:
@@ -135,7 +135,7 @@ class Roles:
         include_totals: bool = True,
         from_param: str | None = None,
         take: int | None = None,
-    ) -> List[dict[str, Any]]:
+    ):
         """List the users that have been associated with a given role.
 
         Args:
@@ -186,7 +186,7 @@ class Roles:
 
     def list_permissions(
         self, id: str, page: int = 0, per_page: int = 25, include_totals: bool = True
-    ) -> List[dict[str, Any]]:
+    ):
         """List the permissions associated to a role.
 
         Args:

--- a/auth0/management/rules.py
+++ b/auth0/management/rules.py
@@ -61,7 +61,7 @@ class Rules:
         page: int | None = None,
         per_page: int | None = None,
         include_totals: bool = False,
-    ) -> list[dict[str, Any]]:
+    ):
         """Retrieves a list of all rules.
 
         Args:

--- a/auth0/management/users.py
+++ b/auth0/management/users.py
@@ -63,7 +63,7 @@ class Users:
         include_totals: bool = True,
         fields: List[str] | None = None,
         include_fields: bool = True,
-    ) -> List[dict[str, Any]]:
+    ):
         """List or search users.
 
         Args:
@@ -170,7 +170,7 @@ class Users:
 
     def list_organizations(
         self, id: str, page: int = 0, per_page: int = 25, include_totals: bool = True
-    ) -> List[dict[str, Any]]:
+    ):
         """List the organizations that the user is member of.
 
         Args:
@@ -198,7 +198,7 @@ class Users:
 
     def list_roles(
         self, id: str, page: int = 0, per_page: int = 25, include_totals: bool = True
-    ) -> List[dict[str, Any]]:
+    ):
         """List the roles associated with a user.
 
         Args:
@@ -254,7 +254,7 @@ class Users:
 
     def list_permissions(
         self, id: str, page: int = 0, per_page: int = 25, include_totals: bool = True
-    ) -> List[dict[str, Any]]:
+    ):
         """List the permissions associated to the user.
 
         Args:
@@ -394,7 +394,7 @@ class Users:
         per_page: int = 50,
         sort: str | None = None,
         include_totals: bool = False,
-    ) -> List[dict[str, Any]]:
+    ):
         """Retrieve every log event for a specific user id.
 
         Args:


### PR DESCRIPTION
### Changes

Paginated endpoints, like `organizations.all_organization_members` return a `list` when `include_totals` is `None` or `False` and a `dict` when `include_totals` is `True`. Currently the return type of these is `list[dict[str, Any]]` and so static type checkers will fail when the developer sets `include_totals=True`.

I've removed the return type for these because:

- The existing return type `list[dict[str, Any]]` is not particularly useful
- Using a Union type will be a breaking change for those using the endpoint without pagination
- Trying to fix this in a non breaking way would require overloads and the `typing-extensions` package (as 3.7 doesn't support `typing.Literal`), which to change the type to return `dict[str, Any]` as well as `list[dict[str, Any]]` is not justified.

Type support for this SDK is only very basic at the moment. But we will improve it in the future if/when we can get structured API data (like OpenAPI 3) from the Auth0 Management API.

### References

fix #509 

### Testing

```py
# foo.py

from auth0 import management

auth0 = management.Auth0(domain="", token="")
data = auth0.organizations.all_organization_members(id="foo", include_totals=True)
print(data.get("total"))
```

```bash
$ mypy foo.py
Success: no issues found in 1 source file
```


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
