### PR TITLE
Revert publishing types

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,7 @@ ignore_errors = True
 
 [mypy-auth0.management.*]
 ignore_errors = False
-disable_error_code=var-annotated, attr-defined
+disable_error_code=var-annotated
 
 [mypy-auth0.rest_async]
 disable_error_code=override


### PR DESCRIPTION
### Changes

This package started publishing types in 4.4, but the way we add async classes and methods makes type checking unfeasible.

Revert publishing types externally until a better solution is available (this will probably be by generating the SDK).

### References

fixes #514 
See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages