### PR TITLE
Fix python dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ files = ["*/__init__.py"]
 folders = [{ path = "auth0" }]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7"
 aiohttp = "^3.8.5"
 pyjwt = "^2.8.0"
 cryptography = "^41.0.3" # pyjwt has a weak dependency on cryptography


### PR DESCRIPTION
### Changes

Fix issue with Python dependency version in 4.4.1

### References

fixes #517 

### Testing

1. Start a new python project with:

```
[tool.poetry.dependencies]
python = ">=3.10"
```

In your pyproject.toml file

3. Add `auth0-python` with poetry `poetry add ../path/to/auth0-python`
