### PR TITLE
[SDK-4656] Add fields to all_organization_members

### DIFF
--- a/auth0/management/organizations.py
+++ b/auth0/management/organizations.py
@@ -246,8 +246,13 @@ class Organizations:
         include_totals: bool = True,
         from_param: str | None = None,
         take: int | None = None,
+        fields: list[str] | None = None,
+        include_fields: bool = True,
     ):
         """Retrieves a list of all the organization members.
+
+        Member roles are not sent by default. Use `fields=roles` to retrieve the roles assigned to each listed member.
+        To use this parameter, you must include the `read:organization_member_roles scope` in the token.
 
         Args:
             id (str): the ID of the organization.
@@ -267,7 +272,14 @@ class Organizations:
             take (int, optional): The total amount of entries to retrieve when
                 using the from parameter. When not set, the default value is up to the server.
 
-        See: https://auth0.com/docs/api/management/v2#!/Organizations/get_members
+            fields (list of str, optional): A list of fields to include or
+              exclude from the result (depending on include_fields). If fields is left blank,
+              all fields (except roles) are returned.
+
+            include_fields (bool, optional): True if the fields specified are
+              to be included in the result, False otherwise. Defaults to True.
+
+        See: https://auth0.com/docs/api/management/v2/organizations/get-members
         """
 
         params = {
@@ -276,6 +288,8 @@ class Organizations:
             "include_totals": str(include_totals).lower(),
             "from": from_param,
             "take": take,
+            "fields": fields and ",".join(fields) or None,
+            "include_fields": str(include_fields).lower(),
         }
 
         return self.client.get(self._url(id, "members"), params=params)

--- a/auth0/test/management/test_organizations.py
+++ b/auth0/test/management/test_organizations.py
@@ -232,6 +232,8 @@ class TestOrganizations(unittest.TestCase):
                 "include_totals": "true",
                 "from": None,
                 "take": None,
+                "fields": None,
+                "include_fields": "true",
             },
         )
 
@@ -253,6 +255,8 @@ class TestOrganizations(unittest.TestCase):
                 "include_totals": "false",
                 "from": None,
                 "take": None,
+                "fields": None,
+                "include_fields": "true",
             },
         )
 
@@ -272,6 +276,29 @@ class TestOrganizations(unittest.TestCase):
                 "page": None,
                 "per_page": None,
                 "include_totals": "true",
+                "fields": None,
+                "include_fields": "true",
+            },
+        )
+
+        # With fields
+        c.all_organization_members("test-org", fields=["a,b"], include_fields=False)
+
+        args, kwargs = mock_instance.get.call_args
+
+        self.assertEqual(
+            "https://domain/api/v2/organizations/test-org/members", args[0]
+        )
+        self.assertEqual(
+            kwargs["params"],
+            {
+                "page": None,
+                "per_page": None,
+                "include_totals": "true",
+                "from": None,
+                "take": None,
+                "fields": "a,b",
+                "include_fields": "false",
             },
         )
 


### PR DESCRIPTION
### Changes

Add `fields` and `include_fields` option to `all_organization_members`

### References

fixes #534 
https://auth0.com/docs/api/management/v2/organizations/get-members