### PR TITLE
Authentication API, the Database classs, Add the organization param to the change_password method

### DIFF
--- a/auth0/authentication/database.py
+++ b/auth0/authentication/database.py
@@ -79,19 +79,27 @@ class Database(AuthenticationBase):
         return data
 
     def change_password(
-        self, email: str, connection: str, password: str | None = None
+        self,
+        email: str,
+        connection: str,
+        password: str | None = None,
+        organization: str | None = None,
     ) -> str:
         """Asks to change a password for a given user.
 
         email (str): The user's email address.
 
         connection (str): The name of the database connection where this user should be created.
+
+        organization (str, optional): The id of the Organization associated with the user.
         """
         body = {
             "client_id": self.client_id,
             "email": email,
             "connection": connection,
         }
+        if organization:
+            body["organization"] = organization
 
         data: str = self.post(
             f"{self.protocol}://{self.domain}/dbconnections/change_password",

--- a/auth0/test/authentication/test_database.py
+++ b/auth0/test/authentication/test_database.py
@@ -78,3 +78,25 @@ class TestDatabase(unittest.TestCase):
                 "connection": "conn",
             },
         )
+
+    @mock.patch("auth0.rest.RestClient.post")
+    def test_change_password_with_organization_param(self, mock_post):
+        d = Database("my.domain.com", "cid")
+
+        # ignores the password argument
+        d.change_password(
+            email="a@b.com", password="pswd", connection="conn", organization="org_id"
+        )
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], "https://my.domain.com/dbconnections/change_password")
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "client_id": "cid",
+                "email": "a@b.com",
+                "connection": "conn",
+                "organization": "org_id",
+            },
+        )


### PR DESCRIPTION
### Changes

Authentication API, the Database class, added the `organization` param to the `change_password` method.

### References

https://auth0.com/docs/api/authentication#change-password

### Testing

- [x] This change adds unit test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
