### PR TITLE
chore(dependencies): Update `cryptography` and pin `urllib3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,11 @@ folders = [{ path = "auth0" }]
 [tool.poetry.dependencies]
 python = ">=3.7"
 aiohttp = "^3.8.5"
+cryptography = "^41.0.5" # pyjwt has a weak dependency on cryptography
 pyjwt = "^2.8.0"
-cryptography = "^41.0.3" # pyjwt has a weak dependency on cryptography
 pyopenssl = "^23.2.0"    # pyopenssl is required to work with cryptography 41+
 requests = "^2.31.0"
+urllib3 = "^2.0.7"       # requests has a weak dependency on urllib3
 
 [tool.poetry.group.dev.dependencies]
 aioresponses = "^0.7.4"


### PR DESCRIPTION
### Changes

This PR:

- Bumps the `cryptography` dependency version to `^41.0.5` (up from `^41.0.3`) to address [CVE-2023-45803](https://www.cve.org/CVERecord?id=CVE-2023-45803).
- Pins the weak dependency for `urllib3` (by way of `requests`) to `^2.0.7` to address [CVE-2023-5363](https://www.cve.org/CVERecord?id=CVE-2023-5363).

### References

N/A

### Testing

N/A

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
