### PR TITLE
Fix rest_async and async tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,15 @@ jobs:
           poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Run tests
+        if: ${{ matrix.python-version != '3.7' }}
         run: |
           poetry run pytest --cov=auth0 --cov-report=term-missing:skip-covered --cov-report=xml
+
+      - name: Run tests 3.7
+        # Skip async tests in 3.7
+        if: ${{ matrix.python-version == '3.7' }}
+        run: |
+          poetry run pytest auth0/test
         # bwrap ${{ env.BUBBLEWRAP_ARGUMENTS }} bash
 
       # - name: Run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Run tests
-        if: ${{ matrix.python-version != '3.7' }}
+        if: ${{ matrix.python-version !== '3.7' }}
         run: |
           poetry run pytest --cov=auth0 --cov-report=term-missing:skip-covered --cov-report=xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Run tests
-        if: ${{ matrix.python-version !== '3.7' }}
+        if: ${{ matrix.python-version != '3.7' }}
         run: |
           poetry run pytest --cov=auth0 --cov-report=term-missing:skip-covered --cov-report=xml
 

--- a/auth0/rest_async.py
+++ b/auth0/rest_async.py
@@ -86,11 +86,11 @@ class AsyncRestClient(RestClient):
         kwargs["timeout"] = self.timeout
         if self._session is not None:
             # Request with re-usable session
-            return self._request_with_session(self.session, *args, **kwargs)
+            return await self._request_with_session(self._session, *args, **kwargs)
         else:
             # Request without re-usable session
             async with aiohttp.ClientSession() as session:
-                return self._request_with_session(session, *args, **kwargs)
+                return await self._request_with_session(session, *args, **kwargs)
 
     async def get(
         self,

--- a/auth0/test_async/test_async_auth0.py
+++ b/auth0/test_async/test_async_auth0.py
@@ -22,13 +22,13 @@ def get_callback(status=200):
     return callback, mock
 
 
-class TestAuth0(unittest.TestCase):
+class TestAuth0(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_get(self, mocked):
         callback, mock = get_callback()
 
-        await mocked.get(clients, callback=callback)
+        mocked.get(clients, callback=callback)
 
         auth0 = Auth0(domain="example.com", token="jwt")
 
@@ -48,8 +48,8 @@ class TestAuth0(unittest.TestCase):
         callback, mock = get_callback()
         callback2, mock2 = get_callback()
 
-        await mocked.get(clients, callback=callback)
-        await mocked.put(factors, callback=callback2)
+        mocked.get(clients, callback=callback)
+        mocked.put(factors, callback=callback2)
 
         async with Auth0(domain="example.com", token="jwt") as auth0:
             self.assertEqual(await auth0.clients.all_async(), payload)

--- a/auth0/test_async/test_async_auth0.py
+++ b/auth0/test_async/test_async_auth0.py
@@ -22,7 +22,11 @@ def get_callback(status=200):
     return callback, mock
 
 
-class TestAuth0(unittest.IsolatedAsyncioTestCase):
+@unittest.skipIf(
+    not hasattr(unittest, "IsolatedAsyncioTestCase"),
+    "python 3.7 doesn't have IsolatedAsyncioTestCase",
+)
+class TestAuth0(getattr(unittest, "IsolatedAsyncioTestCase", object)):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_get(self, mocked):

--- a/auth0/test_async/test_async_auth0.py
+++ b/auth0/test_async/test_async_auth0.py
@@ -22,11 +22,7 @@ def get_callback(status=200):
     return callback, mock
 
 
-@unittest.skipIf(
-    not hasattr(unittest, "IsolatedAsyncioTestCase"),
-    "python 3.7 doesn't have IsolatedAsyncioTestCase",
-)
-class TestAuth0(getattr(unittest, "IsolatedAsyncioTestCase", object)):
+class TestAuth0(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_get(self, mocked):

--- a/auth0/test_async/test_async_token_verifier.py
+++ b/auth0/test_async/test_async_token_verifier.py
@@ -55,13 +55,7 @@ def get_pem_bytes(rsa_public_key):
     )
 
 
-@unittest.skipIf(
-    not hasattr(unittest, "IsolatedAsyncioTestCase"),
-    "python 3.7 doesn't have IsolatedAsyncioTestCase",
-)
-class TestAsyncAsymmetricSignatureVerifier(
-    getattr(unittest, "IsolatedAsyncioTestCase", object)
-):
+class TestAsyncAsymmetricSignatureVerifier(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_async_asymmetric_verifier_fetches_key(self, mocked):
@@ -75,11 +69,7 @@ class TestAsyncAsymmetricSignatureVerifier(
         self.assertEqual(get_pem_bytes(key), RSA_PUB_KEY_1_PEM)
 
 
-@unittest.skipIf(
-    not hasattr(unittest, "IsolatedAsyncioTestCase"),
-    "python 3.7 doesn't have IsolatedAsyncioTestCase",
-)
-class TestAsyncJwksFetcher(getattr(unittest, "IsolatedAsyncioTestCase", object)):
+class TestAsyncJwksFetcher(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     @unittest.mock.patch(
@@ -235,11 +225,7 @@ class TestAsyncJwksFetcher(getattr(unittest, "IsolatedAsyncioTestCase", object))
         self.assertEqual(mock.call_count, 2)
 
 
-@unittest.skipIf(
-    not hasattr(unittest, "IsolatedAsyncioTestCase"),
-    "python 3.7 doesn't have IsolatedAsyncioTestCase",
-)
-class TestAsyncTokenVerifier(getattr(unittest, "IsolatedAsyncioTestCase", object)):
+class TestAsyncTokenVerifier(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_RS256_token_signature_passes(self, mocked):

--- a/auth0/test_async/test_async_token_verifier.py
+++ b/auth0/test_async/test_async_token_verifier.py
@@ -55,12 +55,12 @@ def get_pem_bytes(rsa_public_key):
     )
 
 
-class TestAsyncAsymmetricSignatureVerifier(unittest.TestCase):
+class TestAsyncAsymmetricSignatureVerifier(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_async_asymmetric_verifier_fetches_key(self, mocked):
         callback, mock = get_callback(200, JWKS_RESPONSE_SINGLE_KEY)
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         verifier = AsyncAsymmetricSignatureVerifier(JWKS_URI)
 
@@ -69,7 +69,7 @@ class TestAsyncAsymmetricSignatureVerifier(unittest.TestCase):
         self.assertEqual(get_pem_bytes(key), RSA_PUB_KEY_1_PEM)
 
 
-class TestAsyncJwksFetcher(unittest.TestCase):
+class TestAsyncJwksFetcher(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     @unittest.mock.patch(
@@ -81,8 +81,8 @@ class TestAsyncJwksFetcher(unittest.TestCase):
         fetcher = AsyncJwksFetcher(JWKS_URI, cache_ttl=100)
 
         callback, mock = get_callback(200, JWKS_RESPONSE_SINGLE_KEY)
-        await mocked.get(JWKS_URI, callback=callback)
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         key_1 = await fetcher.get_key("test-key-1")
         expected_key_1_pem = get_pem_bytes(key_1)
@@ -119,8 +119,8 @@ class TestAsyncJwksFetcher(unittest.TestCase):
         fetcher = AsyncJwksFetcher(JWKS_URI, cache_ttl=1)
 
         callback, mock = get_callback(200, JWKS_RESPONSE_MULTIPLE_KEYS)
-        await mocked.get(JWKS_URI, callback=callback)
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         key_1 = await fetcher.get_key("test-key-1")
         key_2 = await fetcher.get_key("test-key-2")
@@ -144,7 +144,7 @@ class TestAsyncJwksFetcher(unittest.TestCase):
         fetcher = AsyncJwksFetcher(JWKS_URI, cache_ttl=1)
 
         callback, mock = get_callback(200, {"keys": [RSA_PUB_KEY_1_JWK]})
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         # Triggers the first call
         key_1 = await fetcher.get_key("test-key-1")
@@ -161,7 +161,7 @@ class TestAsyncJwksFetcher(unittest.TestCase):
         self.assertEqual(mock.call_count, 1)
 
         callback, mock = get_callback(200, JWKS_RESPONSE_MULTIPLE_KEYS)
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         # Triggers the second call
         key_2 = await fetcher.get_key("test-key-2")
@@ -183,7 +183,7 @@ class TestAsyncJwksFetcher(unittest.TestCase):
         fetcher = AsyncJwksFetcher(JWKS_URI, cache_ttl=1)
 
         callback, mock = get_callback(200, JWKS_RESPONSE_SINGLE_KEY)
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         with self.assertRaises(Exception) as err:
             await fetcher.get_key("missing-key")
@@ -206,8 +206,8 @@ class TestAsyncJwksFetcher(unittest.TestCase):
         fetcher = AsyncJwksFetcher(JWKS_URI, cache_ttl=1)
 
         callback, mock = get_callback(500, {})
-        await mocked.get(JWKS_URI, callback=callback)
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         with self.assertRaises(Exception) as err:
             await fetcher.get_key("id1")
@@ -225,12 +225,12 @@ class TestAsyncJwksFetcher(unittest.TestCase):
         self.assertEqual(mock.call_count, 2)
 
 
-class TestAsyncTokenVerifier(unittest.TestCase):
+class TestAsyncTokenVerifier(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_RS256_token_signature_passes(self, mocked):
         callback, mock = get_callback(200, {"keys": [PUBLIC_KEY]})
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         issuer = "https://tokens-test.auth0.com/"
         audience = "tokens-test-123"
@@ -261,7 +261,7 @@ class TestAsyncTokenVerifier(unittest.TestCase):
         callback, mock = get_callback(
             200, {"keys": [RSA_PUB_KEY_1_JWK]}
         )  # different pub key
-        await mocked.get(JWKS_URI, callback=callback)
+        mocked.get(JWKS_URI, callback=callback)
 
         issuer = "https://tokens-test.auth0.com/"
         audience = "tokens-test-123"

--- a/auth0/test_async/test_async_token_verifier.py
+++ b/auth0/test_async/test_async_token_verifier.py
@@ -55,7 +55,13 @@ def get_pem_bytes(rsa_public_key):
     )
 
 
-class TestAsyncAsymmetricSignatureVerifier(unittest.IsolatedAsyncioTestCase):
+@unittest.skipIf(
+    not hasattr(unittest, "IsolatedAsyncioTestCase"),
+    "python 3.7 doesn't have IsolatedAsyncioTestCase",
+)
+class TestAsyncAsymmetricSignatureVerifier(
+    getattr(unittest, "IsolatedAsyncioTestCase", object)
+):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_async_asymmetric_verifier_fetches_key(self, mocked):
@@ -69,7 +75,11 @@ class TestAsyncAsymmetricSignatureVerifier(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(get_pem_bytes(key), RSA_PUB_KEY_1_PEM)
 
 
-class TestAsyncJwksFetcher(unittest.IsolatedAsyncioTestCase):
+@unittest.skipIf(
+    not hasattr(unittest, "IsolatedAsyncioTestCase"),
+    "python 3.7 doesn't have IsolatedAsyncioTestCase",
+)
+class TestAsyncJwksFetcher(getattr(unittest, "IsolatedAsyncioTestCase", object)):
     @pytest.mark.asyncio
     @aioresponses()
     @unittest.mock.patch(
@@ -225,7 +235,11 @@ class TestAsyncJwksFetcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mock.call_count, 2)
 
 
-class TestAsyncTokenVerifier(unittest.IsolatedAsyncioTestCase):
+@unittest.skipIf(
+    not hasattr(unittest, "IsolatedAsyncioTestCase"),
+    "python 3.7 doesn't have IsolatedAsyncioTestCase",
+)
+class TestAsyncTokenVerifier(getattr(unittest, "IsolatedAsyncioTestCase", object)):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_RS256_token_signature_passes(self, mocked):

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -54,7 +54,11 @@ def get_callback(status=200, response=None):
     return callback, mock
 
 
-class TestAsyncify(unittest.IsolatedAsyncioTestCase):
+@unittest.skipIf(
+    not hasattr(unittest, "IsolatedAsyncioTestCase"),
+    "python 3.7 doesn't have IsolatedAsyncioTestCase",
+)
+class TestAsyncify(getattr(unittest, "IsolatedAsyncioTestCase", object)):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_get(self, mocked):

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -54,12 +54,12 @@ def get_callback(status=200, response=None):
     return callback, mock
 
 
-class TestAsyncify(unittest.TestCase):
+class TestAsyncify(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_get(self, mocked):
         callback, mock = get_callback()
-        await mocked.get(clients, callback=callback)
+        mocked.get(clients, callback=callback)
         c = asyncify(Clients)(domain="example.com", token="jwt")
         self.assertEqual(await c.all_async(), payload)
         mock.assert_called_with(
@@ -74,7 +74,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_post(self, mocked):
         callback, mock = get_callback()
-        await mocked.post(clients, callback=callback)
+        mocked.post(clients, callback=callback)
         c = asyncify(Clients)(domain="example.com", token="jwt")
         data = {"client": 1}
         self.assertEqual(await c.create_async(data), payload)
@@ -90,7 +90,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_post_auth(self, mocked):
         callback, mock = get_callback()
-        await mocked.post(token, callback=callback)
+        mocked.post(token, callback=callback)
         c = asyncify(GetToken)("example.com", "cid", client_secret="clsec")
         self.assertEqual(
             await c.login_async(username="usrnm", password="pswd"), payload
@@ -116,7 +116,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_user_info(self, mocked):
         callback, mock = get_callback()
-        await mocked.get(user_info, callback=callback)
+        mocked.get(user_info, callback=callback)
         c = asyncify(Users)(domain="example.com")
         self.assertEqual(
             await c.userinfo_async(access_token="access-token-example"), payload
@@ -133,7 +133,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_file_post(self, mocked):
         callback, mock = get_callback()
-        await mocked.post(users_imports, callback=callback)
+        mocked.post(users_imports, callback=callback)
         j = asyncify(Jobs)(domain="example.com", token="jwt")
         users = TemporaryFile()
         self.assertEqual(await j.import_users_async("connection-1", users), payload)
@@ -158,7 +158,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_patch(self, mocked):
         callback, mock = get_callback()
-        await mocked.patch(clients, callback=callback)
+        mocked.patch(clients, callback=callback)
         c = asyncify(Clients)(domain="example.com", token="jwt")
         data = {"client": 1}
         self.assertEqual(await c.update_async("client-1", data), payload)
@@ -174,7 +174,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_put(self, mocked):
         callback, mock = get_callback()
-        await mocked.put(factors, callback=callback)
+        mocked.put(factors, callback=callback)
         g = asyncify(Guardian)(domain="example.com", token="jwt")
         data = {"factor": 1}
         self.assertEqual(await g.update_factor_async("factor-1", data), payload)
@@ -190,7 +190,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_delete(self, mocked):
         callback, mock = get_callback()
-        await mocked.delete(clients, callback=callback)
+        mocked.delete(clients, callback=callback)
         c = asyncify(Clients)(domain="example.com", token="jwt")
         self.assertEqual(await c.delete_async("client-1"), payload)
         mock.assert_called_with(
@@ -206,7 +206,7 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_shared_session(self, mocked):
         callback, mock = get_callback()
-        await mocked.get(clients, callback=callback)
+        mocked.get(clients, callback=callback)
         async with asyncify(Clients)(domain="example.com", token="jwt") as c:
             self.assertEqual(await c.all_async(), payload)
         mock.assert_called_with(
@@ -221,10 +221,10 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_rate_limit(self, mocked):
         callback, mock = get_callback(status=429)
-        await mocked.get(clients, callback=callback)
-        await mocked.get(clients, callback=callback)
-        await mocked.get(clients, callback=callback)
-        await mocked.get(clients, payload=payload)
+        mocked.get(clients, callback=callback)
+        mocked.get(clients, callback=callback)
+        mocked.get(clients, callback=callback)
+        mocked.get(clients, payload=payload)
         c = asyncify(Clients)(domain="example.com", token="jwt")
         rest_client = c._async_client.client
         rest_client._skip_sleep = True
@@ -237,21 +237,21 @@ class TestAsyncify(unittest.TestCase):
     @aioresponses()
     async def test_rate_limit_post(self, mocked):
         callback, mock = get_callback(status=429)
-        await mocked.post(clients, callback=callback)
-        await mocked.post(clients, callback=callback)
-        await mocked.post(clients, callback=callback)
-        await mocked.post(clients, payload=payload)
+        mocked.post(clients, callback=callback)
+        mocked.post(clients, callback=callback)
+        mocked.post(clients, callback=callback)
+        mocked.post(clients, payload=payload)
         c = asyncify(Clients)(domain="example.com", token="jwt")
         rest_client = c._async_client.client
         rest_client._skip_sleep = True
-        self.assertEqual(await c.all_async(), payload)
+        self.assertEqual(await c.create_async({}), payload)
         self.assertEqual(3, mock.call_count)
 
     @pytest.mark.asyncio
     @aioresponses()
     async def test_timeout(self, mocked):
         callback, mock = get_callback()
-        await mocked.get(clients, callback=callback)
+        mocked.get(clients, callback=callback)
         c = asyncify(Clients)(domain="example.com", token="jwt", timeout=(8.8, 9.9))
         self.assertEqual(await c.all_async(), payload)
         mock.assert_called_with(

--- a/auth0/test_async/test_asyncify.py
+++ b/auth0/test_async/test_asyncify.py
@@ -54,11 +54,7 @@ def get_callback(status=200, response=None):
     return callback, mock
 
 
-@unittest.skipIf(
-    not hasattr(unittest, "IsolatedAsyncioTestCase"),
-    "python 3.7 doesn't have IsolatedAsyncioTestCase",
-)
-class TestAsyncify(getattr(unittest, "IsolatedAsyncioTestCase", object)):
+class TestAsyncify(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     @aioresponses()
     async def test_get(self, mocked):


### PR DESCRIPTION
### Changes

Broke rest_sync in #518 and an issue in the async tests meant it didn't get picked up.

### References

fixes #555 
