### PR TITLE
Fix py 3.12 build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           sudo apt install bubblewrap
           pip install --user --upgrade pip
           pip install --user pipx
+          pip install --user setuptools
           pipx ensurepath
           pipx install poetry==1.4.2
           poetry config virtualenvs.in-project true


### PR DESCRIPTION
Build is failing on CI for python 3.12 because https://github.com/pypa/setuptools/issues/3661