### PR TITLE
ci(publish): make contents write and fix secrets reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 ### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
 
 permissions:
-  contents: read
+  contents: write
   id-token: write # Required for trusted publishing to PyPI
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
       - id: get_release_notes
         uses: ./.github/actions/get-release-notes
         with:
-          token: ${{ secrets.github-token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}
           repo_owner: ${{ github.repository_owner }}
           repo_name: ${{ github.event.repository.name }}
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/tag-exists
         with:
           tag: ${{ steps.get_version.outputs.version }}
-          token: ${{ secrets.github-token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # If the tag already exists, exit with an error
       - if: steps.tag_exists.outputs.exists == 'true'
@@ -83,7 +83,7 @@ jobs:
       # Create a release for the tag
       - uses: ./.github/actions/release-create
         with:
-          token: ${{ secrets.github-token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.get_version.outputs.version }}
           body: ${{ steps.get_release_notes.outputs.release-notes }}
           tag: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
### Changes

Comparing with [other repos ](https://github.com/auth0/auth0-spa-js/blob/4314cf05d6fbe59bfbef6e73453ca4c65a1f92b5/.github/workflows/release.yml#L10)it seems like the permissions and github_token secret were referenced differently, I think that should fix the issue seen when attempting to publish 🤞🏻 

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
