### PR TITLE
ci(publish): create release before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,9 +77,6 @@ jobs:
         run: |
           poetry build
 
-      - name: Publish release
-        uses: pypa/gh-action-pypi-publish@release/v1
-
       # Create a release for the tag
       - uses: ./.github/actions/release-create
         with:
@@ -89,3 +86,6 @@ jobs:
           tag: ${{ steps.get_version.outputs.version }}
           commit: ${{ github.sha }}
           prerelease: ${{ steps.get_prerelease.outputs.prerelease }}
+
+      - name: Publish release
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION

### Changes

Publishing requires the tag to exist so it can get the version, so switch the order round

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
