### PR TITLE
ci(publish): move release creation before any poetry steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,16 @@ jobs:
       - if: steps.tag_exists.outputs.exists == 'true'
         run: exit 1
 
+      # Create a release for the tag
+      - uses: ./.github/actions/release-create
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ steps.get_version.outputs.version }}
+          body: ${{ steps.get_release_notes.outputs.release-notes }}
+          tag: ${{ steps.get_version.outputs.version }}
+          commit: ${{ github.sha }}
+          prerelease: ${{ steps.get_prerelease.outputs.prerelease }}
+
       - name: Configure Python
         uses: actions/setup-python@v5
         with:
@@ -76,16 +86,6 @@ jobs:
       - name: Build release
         run: |
           poetry build
-
-      # Create a release for the tag
-      - uses: ./.github/actions/release-create
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ steps.get_version.outputs.version }}
-          body: ${{ steps.get_release_notes.outputs.release-notes }}
-          tag: ${{ steps.get_version.outputs.version }}
-          commit: ${{ github.sha }}
-          prerelease: ${{ steps.get_prerelease.outputs.prerelease }}
 
       - name: Publish release
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Changes

Poetry build seems to create versioned content, so we need the tag made before even that step

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
