### PR TITLE
ci(publish): only run on manual workflow, remove tag check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish Release
 
 on:
-  pull_request:
-    types:
-      - closed
   workflow_dispatch:
 
 ### TODO: Replace instances of './.github/actions/' with reference to the `dx-sdk-actions` repo is made public and this file is transferred over
@@ -46,17 +43,6 @@ jobs:
           version: ${{ steps.get_version.outputs.version }}
           repo_owner: ${{ github.repository_owner }}
           repo_name: ${{ github.event.repository.name }}
-
-      # Check if the tag already exists
-      - id: tag_exists
-        uses: ./.github/actions/tag-exists
-        with:
-          tag: ${{ steps.get_version.outputs.version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # If the tag already exists, exit with an error
-      - if: steps.tag_exists.outputs.exists == 'true'
-        run: exit 1
 
       # Create a release for the tag
       - uses: ./.github/actions/release-create


### PR DESCRIPTION
### Changes

Given that we create the release/tag via the API, the local git repo doesn't get updated so the poetry dynamic versioning still can't find the tag.

To make things simpler for now, I propose we make this repo a manual release trigger and change the new release flow to:
* Release PR made
* Release PR merged
* Tag created and merged
* Release workflow triggered

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
