### PR TITLE
Adding Support For RAR and JAR Requests

### DIFF
--- a/auth0/authentication/pushed_authorization_requests.py
+++ b/auth0/authentication/pushed_authorization_requests.py
@@ -16,6 +16,8 @@ class PushedAuthorizationRequests(AuthenticationBase):
              redirect_uri (str): The URL to which Auth0 will redirect the browser after authorization has been granted
              by the user.
              **kwargs: Other fields to send along with the PAR.
+             For RAR requests, authorization_details parameter should be added in a proper format. See:https://datatracker.ietf.org/doc/html/rfc9396
+             For JAR requests, requests parameter should be send with the JWT as the value. See: https://datatracker.ietf.org/doc/html/rfc9126#name-the-request-request-paramet
 
         See: https://www.rfc-editor.org/rfc/rfc9126.html
         """

--- a/auth0/test/authentication/test_pushed_authorization_requests.py
+++ b/auth0/test/authentication/test_pushed_authorization_requests.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 from unittest import mock
 
 from ...authentication.pushed_authorization_requests import PushedAuthorizationRequests
@@ -44,4 +45,60 @@ class TestRevokeToken(unittest.TestCase):
                 "redirect_uri": "https://example.com/callback",
                 "foo": "bar",
             },
+        )
+
+    @mock.patch("auth0.rest.RestClient.post")
+    def test_rar(self, mock_post):
+        a = PushedAuthorizationRequests("my.domain.com", "cid", client_secret="sh!")
+        a.pushed_authorization_request(
+            response_type="code", 
+            redirect_uri="https://example.com/callback", 
+            authorization_details=[{"type": "money_transfer", "instructedAmount": {"amount": 2500, "currency": "USD"}}],
+        )
+
+        args, kwargs = mock_post.call_args
+
+        expected_data = {
+            "client_id": "cid",
+            "client_secret": "sh!",
+            "response_type": "code",
+            "redirect_uri": "https://example.com/callback",
+            "authorization_details": [{"type": "money_transfer", "instructedAmount": {"amount": 2500, "currency": "USD"}}],
+        }
+
+        actual_data = kwargs["data"]
+        
+        self.assertEqual(args[0], "https://my.domain.com/oauth/par")
+   
+        self.assertEqual(
+            json.dumps(actual_data, sort_keys=True), 
+            json.dumps(expected_data, sort_keys=True)
+        )
+
+    @mock.patch("auth0.rest.RestClient.post")
+    def test_jar(self, mock_post):
+        a = PushedAuthorizationRequests("my.domain.com", "cid", client_secret="sh!")
+        a.pushed_authorization_request(
+            response_type="code", 
+            redirect_uri="https://example.com/callback", 
+            request="my-jwt-request",
+        )
+
+        args, kwargs = mock_post.call_args
+
+        expected_data = {
+            "client_id": "cid",
+            "client_secret": "sh!",
+            "response_type": "code",
+            "redirect_uri": "https://example.com/callback",
+            "request": 'my-jwt-request',
+        }
+
+        actual_data = kwargs["data"]
+        
+        self.assertEqual(args[0], "https://my.domain.com/oauth/par")
+   
+        self.assertEqual(
+            json.dumps(actual_data, sort_keys=True), 
+            json.dumps(expected_data, sort_keys=True)
         )


### PR DESCRIPTION
### Changes

- Added test cases for RAR and JAR Requests.


### References

- [JAR](https://datatracker.ietf.org/doc/html/rfc9126#name-the-request-request-paramet)

- [RAR](https://auth0.com/docs/get-started/applications/configure-client-initiated-backchannel-authentication#integrate-guardian-sdk-into-your-application)

### Testing

- [x] This change adds test coverage

     1.  To test RAR changes, user has to first [configure resource server api](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar)
     2. To test the JAR changes, user has to [generate a JAR request](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-jar), then add the generated JWT to newly added request parameter.

- [x] This change has been tested on the latest version of the platform/language or why not

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).