### PR TITLE
Add support for federated connection token exchange

### DIFF
--- a/auth0/authentication/get_token.py
+++ b/auth0/authentication/get_token.py
@@ -292,7 +292,7 @@ class GetToken(AuthenticationBase):
             login_hint (str, optional): The login hint to use.
 
         Returns:
-            access_token, expires_in, scope
+            access_token, expires_in, scope, issued_token_type, token_type
         """
 
         data = {

--- a/auth0/authentication/get_token.py
+++ b/auth0/authentication/get_token.py
@@ -195,7 +195,6 @@ class GetToken(AuthenticationBase):
 
         Args:
             refresh_token (str): The refresh token returned from the initial token request.
-
             scope (str): Use this to limit the scopes of the new access token.
             Multiple scopes are separated with whitespace.
 
@@ -236,7 +235,6 @@ class GetToken(AuthenticationBase):
             Multiple scopes are separated with whitespace.
 
             audience (str): The unique identifier of the target API you want to access.
-
         Returns:
             access_token, id_token
         """
@@ -276,4 +274,40 @@ class GetToken(AuthenticationBase):
                 "auth_req_id": auth_req_id,
                 "grant_type": grant_type,
             },
+        )
+
+    def federated_connection_token(
+        self,
+        refresh_token: str,
+        connection: str,
+        login_hint: str | None = None,
+    ) -> Any:
+        """Calls oauth/token endpoint with token-exchange:federated-connection-access-token grant type
+
+        Args:
+            refresh_token (str): The refresh token returned from the initial token request.
+
+            connection (str): The name of the connection to use.
+
+            login_hint (str, optional): The login hint to use.
+
+        Returns:
+            access_token, expires_in, scope
+        """
+
+        data = {
+            "client_id": self.client_id,
+            "grant_type": "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token",
+            "connection": connection,
+            "subject_token": refresh_token,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:refresh_token",
+            "requested_token_type": "http://auth0.com/oauth/token-type/federated-connection-access-token",
+        }
+
+        if login_hint:
+            data["login_hint"] = login_hint
+
+        return self.authenticated_post(
+            f"{self.protocol}://{self.domain}/oauth/token",
+            data=data,
         )

--- a/auth0/test/authentication/test_get_token.py
+++ b/auth0/test/authentication/test_get_token.py
@@ -335,3 +335,48 @@ class TestGetToken(unittest.TestCase):
                 "grant_type": "urn:openid:params:grant-type:ciba",
             },
         )
+
+    @mock.patch("auth0.rest.RestClient.post")
+    def test_federated_connection_token(self, mock_post):
+
+
+        g = GetToken("my.domain.com", "<client_id>", client_secret="<client_secret>")
+
+        g.federated_connection_token(refresh_token='<refresh_token>', connection='<connection_name>')
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], "https://my.domain.com/oauth/token")
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "client_id": "<client_id>",
+                "client_secret": "<client_secret>",
+                "grant_type": "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token",
+                "connection": "<connection_name>",
+                "subject_token": "<refresh_token>",
+                "subject_token_type": "urn:ietf:params:oauth:token-type:refresh_token",
+                "requested_token_type": "http://auth0.com/oauth/token-type/federated-connection-access-token",
+            }
+        )
+
+        
+        # Get a new federated connection access token with a login hint
+        g.federated_connection_token(refresh_token='<refresh_token>', connection='<connection_name>', login_hint='<login_hint>')
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], "https://my.domain.com/oauth/token")
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "client_id": "<client_id>",
+                "client_secret": "<client_secret>",
+                "grant_type": "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token",
+                "connection": "<connection_name>",
+                "subject_token": "<refresh_token>",
+                "subject_token_type": "urn:ietf:params:oauth:token-type:refresh_token",
+                "requested_token_type": "http://auth0.com/oauth/token-type/federated-connection-access-token",
+                'login_hint': '<login_hint>',
+            }
+        )


### PR DESCRIPTION
### Changes

This PR adds support for federated connection token exchange.

### References

N/A

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
