### PR TITLE
fix:Change the federated connection function name

### DIFF
--- a/auth0/authentication/get_token.py
+++ b/auth0/authentication/get_token.py
@@ -278,7 +278,7 @@ class GetToken(AuthenticationBase):
             },
         )
     
-    def federated_connection_access_token(
+    def access_token_for_connection(
         self,
         subject_token_type: str, 
         subject_token: str,

--- a/auth0/test/authentication/test_get_token.py
+++ b/auth0/test/authentication/test_get_token.py
@@ -340,7 +340,7 @@ class TestGetToken(unittest.TestCase):
     def test_federated_login(self, mock_post):
         g = GetToken("my.domain.com", "cid", client_secret="csec")
 
-        g.federated_connection_access_token(
+        g.access_token_for_connection(
             grant_type="urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token",
             subject_token_type="urn:ietf:params:oauth:token-type:refresh_token",
             subject_token="refid",

--- a/auth0/test/authentication/test_get_token.py
+++ b/auth0/test/authentication/test_get_token.py
@@ -337,7 +337,7 @@ class TestGetToken(unittest.TestCase):
         )
 
     @mock.patch("auth0.rest.RestClient.post")
-    def test_federated_login(self, mock_post):
+    def test_connection_login(self, mock_post):
         g = GetToken("my.domain.com", "cid", client_secret="csec")
 
         g.access_token_for_connection(


### PR DESCRIPTION
### Changes

- Modified the  function name from `federated_access_token` to `access_token_for_connection`.


### Testing

- [x] This change adds test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).