### PR TITLE
fix: add missing indentation for Python configuration step

### DIFF
--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Configure Python
         uses: actions/setup-python@v6
+        with:
           python-version: ${{ inputs.python-version }}
 
       - name: Configure dependencies


### PR DESCRIPTION
### Changes

- Fix the `RL-Scanner `Workflow
