### PR TITLE
fix(rest): tolerate malformed `x-ratelimit-reset` in 429 handling

### DIFF
--- a/auth0/rest.py
+++ b/auth0/rest.py
@@ -284,7 +284,11 @@ class Response:
     def content(self) -> Any:
         if self._is_error():
             if self._status_code == 429:
-                reset_at = int(self._headers.get("x-ratelimit-reset", "-1"))
+                raw_reset = self._headers.get("x-ratelimit-reset")
+                try:
+                    reset_at = int(raw_reset) if raw_reset is not None else -1
+                except (ValueError, TypeError):
+                    reset_at = -1
                 raise RateLimitError(
                     error_code=self._error_code(),
                     message=self._error_message(),


### PR DESCRIPTION
`Response.content()` cast the `x-ratelimit-reset` header to int without validation. If a 429 response included a non-integer (or garbage) value, `int()` raised ValueError and the call crashed instead of raising a structured `RateLimitError`. Parse defensively and fall back to `-1` when missing/malformed so clients always receive `RateLimitError` as intended.

### Testing

Simulate a server response with something like this:

```
from auth0.exceptions import RateLimitError
from auth0.rest import Response

bad_headers = {"x-ratelimit-reset": "NaN"}  # or any non-integer
r = Response(429, {"error":"rate_limited"}, bad_headers)
r.content()  # raises ValueError today (expected: RateLimitError with reset_at=-1)
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
