### PR TITLE
Release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [5.1.0](https://github.com/auth0/auth0-python/tree/5.1.0) (2026-02-10)
+## [5.1.0](https://github.com/auth0/auth0-python/tree/5.1.0) (2026-02-11)
 [Full Changelog](https://github.com/auth0/auth0-python/compare/5.0.0...5.1.0)
 
 **Fixed**

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Auth0 Python library provides convenient access to the Auth0 APIs from Pytho
 
 ## Installation
 ```sh
-pip install auth0-python==5.0.0
+pip install auth0-python
 ```
 
 **Requirements:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "auth0-python"
 
 [tool.poetry]
 name = "auth0-python"
-version = "5.0.0"
+version = "5.1.0"
 description = "Auth0 Python SDK - Management and Authentication APIs"
 readme = "README.md"
 authors = ["Auth0 <support@auth0.com>"]


### PR DESCRIPTION
**Fixed**

- fix: Remove placeholder defaults from optional parameters + additional updates     [\#778](https://github.com/auth0/auth0-python/pull/778) ([fern-api[bot]](https://github.com/apps/fern-api))