### PR TITLE
fix(types): allow user_id to accept int values in UserIdentitySchema

### DIFF
--- a/src/auth0/management/types/user_identity_schema.py
+++ b/src/auth0/management/types/user_identity_schema.py
@@ -16,7 +16,7 @@ class UserIdentitySchema(UniversalBaseModel):
     Name of the connection containing this identity.
     """
 
-    user_id: typing.Optional[str] = pydantic.Field(default=None)
+    user_id: typing.Optional[typing.Union[str, int]] = pydantic.Field(default=None)
     """
     Unique identifier of the user user for this identity.
     """


### PR DESCRIPTION
## Description

GitHub (and possibly other social) identity providers return `user_id` as an integer in the identities array. The current `Optional[str]` typing causes a Pydantic validation error when calling `users.get()` for accounts linked with such providers:

```
1 validation error for GetUserResponseContent
identities.0.user_id
  Input should be a valid string [type=string_type, input_value=123456789, input_type=int]
```

## Changes

Relax the `user_id` field type from `Optional[str]` to `Optional[Union[str, int]]` to match actual API behavior where the value can be either a string or an integer depending on the identity provider.

Fixes #826