### PR TITLE
chore: Remove management/__init__.py from .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -16,9 +16,8 @@ CHANGELOG.md
 src/auth0/authentication/
 tests/authentication/
 
-# Root auth0 __init__.pys
+# Root auth0 __init__.py
 src/auth0/__init__.py
-src/auth0/management/__init__.py
 
 # Telemetry customization (Auth0 format with dynamic versioning)
 src/auth0/management/core/client_wrapper.py


### PR DESCRIPTION
## Summary

- Removes `src/auth0/management/__init__.py` from `.fernignore` so the Fern generator (5.8.4) can manage it directly
- Generator version 5.8.4 includes the Replay fix for `__init__.py` handling

## Next steps

After regeneration, a follow-up commit will restore custom wiring in `management/__init__.py`:
- `TYPE_CHECKING` imports for `ManagementClient`, `AsyncManagementClient`, `CustomDomainHeader`, `TokenProvider`, `AsyncTokenProvider`
- 5 `_dynamic_imports` entries for those classes
- 3 `__all__` entries (`ManagementClient`, `AsyncManagementClient`, `CustomDomainHeader`)

Replay will preserve these additions in future regenerations.