### PR TITLE
fix(.fern/replay.lock): re-anchor on reachable [fern-replay] init commit

### DIFF
--- a/.fern/replay.lock
+++ b/.fern/replay.lock
@@ -6,21 +6,20 @@ generations:
     timestamp: 2026-04-28T17:41:46.911Z
     cli_version: unknown
     generator_versions: {}
-  - commit_sha: b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d
-    tree_hash: 063654dc375085f1a8bea81c0b92c9f5a2416241
-    timestamp: 2026-05-01T07:46:03.366Z
+  - commit_sha: ffe61f6a098cb25a875019a37f2615045b97344e
+    tree_hash: d03a986a5da90661589bd53a6afdd5725588658c
+    timestamp: 2026-04-29T20:01:22+05:30
     cli_version: unknown
-    generator_versions:
-      fernapi/fern-python-sdk: 5.9.1
-    base_branch_head: 6e9c9a600c40b731e00bbf7f4e4285fe7758c0b5
-current_generation: b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d
+    generator_versions: {}
+    base_branch_head: de316f0260ef1fa7c3626cbe771b167fd119439c
+current_generation: ffe61f6a098cb25a875019a37f2615045b97344e
 patches:
   - id: patch-4894603d
     content_hash: sha256:07bdd182f3a0fcf3bb41c2edeae2ae065fc98ce0dcae83201bde3e2140f9882d
     original_commit: 4894603d03409962bc60a34712de8abffe919e2c
     original_message: "chore: Restore custom wiring in management/__init__.py"
     original_author: Kunal Dawar <kunal.dawar@okta.com>
-    base_generation: b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d
+    base_generation: ffe61f6a098cb25a875019a37f2615045b97344e
     files:
       - src/auth0/management/__init__.py
     patch_content: |


### PR DESCRIPTION
## Why this PR exists

`.fern/replay.lock` on master references the commit SHA `b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d` in three fields: `current_generation`, the second entry in `generations[]`, and `patch-4894603d.base_generation`. That SHA exists on the abandoned bot branch `fern-bot/2026-05-01_07-46-04_377` but is **unreachable from `master`'s first-parent history**, because PR #836 ("SDK regeneration", merged 2026-05-01) was squash-merged — squash created a new merge commit `9398d1da…` on master and discarded the original bot-branch SHAs.

The result is that every subsequent `fern generate` loads this lockfile, can't resolve `b61c6fa` from a master-only clone, falls into the deepest detection fallback path, and (until the engine fix linked below also lands) captures up to 200 pre-Fern commits as orphan patches — overflowing GitHub's 65,536-character PR body limit and failing PR creation outright.

## What this PR changes

Three references on `.fern/replay.lock`, no other lines touched:

\`\`\`diff
-  - commit_sha: b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d
-    tree_hash: 063654dc375085f1a8bea81c0b92c9f5a2416241
-    timestamp: 2026-05-01T07:46:03.366Z
-    cli_version: unknown
-    generator_versions:
-      fernapi/fern-python-sdk: 5.9.1
-    base_branch_head: 6e9c9a600c40b731e00bbf7f4e4285fe7758c0b5
-current_generation: b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d
+  - commit_sha: ffe61f6a098cb25a875019a37f2615045b97344e
+    tree_hash: d03a986a5da90661589bd53a6afdd5725588658c
+    timestamp: 2026-04-29T20:01:22+05:30
+    cli_version: unknown
+    generator_versions: {}
+    base_branch_head: de316f0260ef1fa7c3626cbe771b167fd119439c
+current_generation: ffe61f6a098cb25a875019a37f2615045b97344e
\`\`\`

\`\`\`diff
-    base_generation: b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d
+    base_generation: ffe61f6a098cb25a875019a37f2615045b97344e
\`\`\`

`ffe61f6a098cb25a875019a37f2615045b97344e` is the merge commit on master for PR #833 ("[fern-replay] Initialize Replay for SDK customizations"), authored by `fern-api[bot]`. Unlike `b61c6fa…`, it sits on master's first-parent history and is reachable from any clone of master.

`patch_content` and the ~8,200-line `theirs_snapshot` (which contains the full intended content of `src/auth0/management/__init__.py`) are untouched — they're the safety net that lets the replay applicator reconstruct the customer-intended file content on the next regeneration even if the line-anchored diff's context has drifted against the new anchor's tree.

## Effect after merge

- Next `fern generate` loads the lockfile, finds `current_generation: ffe61f6…` reachable from master
- Replay uses its linear detection path (not the broken fallback)
- The 5 customer commits since PR #833 get tracked normally with valid `base_generation` anchors
- `patch-4894603d` reapplies, preserving the custom wiring in `src/auth0/management/__init__.py`
- PR body well under GitHub's 65KB limit
